### PR TITLE
Dependabot updates 05 28 2025

### DIFF
--- a/example-app/pom.xml
+++ b/example-app/pom.xml
@@ -17,16 +17,28 @@
         <maven.compiler.target>21</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <spring.boot.version>3.4.3</spring.boot.version>
+        <spring.boot.version>3.4.5</spring.boot.version>
         <slf4j.version>2.0.17</slf4j.version>
         <h2.version>2.3.232</h2.version>
-        <junit-jupiter.version>5.12.1</junit-jupiter.version>
-        <projectreactor.version>3.7.4</projectreactor.version>
-        <jackson.version>2.18.3</jackson.version>
-        <httpclient5.version>5.4.1</httpclient5.version>
+        <junit-jupiter.version>5.12.2</junit-jupiter.version>
+        <projectreactor.version>3.7.5</projectreactor.version>
+        <jackson.version>2.19.0</jackson.version>
+        <httpclient5.version>5.4.3</httpclient5.version>
         <bouncycastle.version>1.80</bouncycastle.version>
-        <mysql-connector.version>9.2.0</mysql-connector.version>
+        <mysql-connector.version>9.3.0</mysql-connector.version>
     </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.junit</groupId>
+                <artifactId>junit-bom</artifactId>
+                <version>${junit-jupiter.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <dependencies>
         <dependency>
@@ -61,20 +73,7 @@
 
         <dependency>
             <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-api</artifactId>
-            <version>${junit-jupiter.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-params</artifactId>
-            <version>${junit-jupiter.version}</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-engine</artifactId>
+            <artifactId>junit-jupiter</artifactId>
             <version>${junit-jupiter.version}</version>
             <scope>test</scope>
         </dependency>
@@ -159,7 +158,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.5.2</version>
+                <version>3.5.3</version>
                 <configuration>
                     <includes>
                         <include>**/*Test.java</include>
@@ -230,7 +229,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>3.5.2</version>
+                <version>3.5.3</version>
                 <executions>
                     <execution>
                         <goals>

--- a/library/pom.xml
+++ b/library/pom.xml
@@ -45,20 +45,32 @@
     <!--     Dependency versions-->
         <commons-net.version>3.11.1</commons-net.version>
         <commons-lang3.version>3.17.0</commons-lang3.version>
-        <projectlombok.version>1.18.36</projectlombok.version>
+        <projectlombok.version>1.18.38</projectlombok.version>
         <dnsjava.version>3.6.3</dnsjava.version>
-        <httpcomponents.version>5.4.2</httpcomponents.version>
+        <httpcomponents.version>5.4.4</httpcomponents.version>
         <slf4j.version>2.0.17</slf4j.version>
-        <logback.version>1.5.17</logback.version>
+        <logback.version>1.5.18</logback.version>
         <bouncycastle.version>1.80</bouncycastle.version>
         <guava.version>33.2.1-jre</guava.version>
         <icu.version>77.1</icu.version>
     <!--    TEST versions -->
-        <mockito.version>5.16.0</mockito.version>
-        <jupiter.version>5.11.4</jupiter.version>
+        <mockito.version>5.17.0</mockito.version>
+        <jupiter.version>5.12.2</jupiter.version>
         <mock-server.version>5.15.0</mock-server.version>
         <sonar.coverage.jacoco.xmlReportPaths>./target/site/jacoco-aggregate/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
     </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.junit</groupId>
+                <artifactId>junit-bom</artifactId>
+                <version>${jupiter.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <dependencies>
         <dependency>
@@ -144,14 +156,7 @@
 
         <dependency>
             <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-engine</artifactId>
-            <version>${jupiter.version}</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-params</artifactId>
+            <artifactId>junit-jupiter</artifactId>
             <version>${jupiter.version}</version>
             <scope>test</scope>
         </dependency>
@@ -174,17 +179,17 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.5.2</version>
+                <version>3.5.3</version>
             </plugin>
             <plugin>
                 <groupId>org.sonarsource.scanner.maven</groupId>
                 <artifactId>sonar-maven-plugin</artifactId>
-                <version>5.0.0.4389</version>
+                <version>5.1.0.4751</version>
             </plugin>
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.12</version>
+                <version>0.8.13</version>
             </plugin>
 
         </plugins>


### PR DESCRIPTION
Updating dependencies to the following versions

spring-boot -> 3.4.5
junit-jupiter -> 5.12.2
projectreactor -> 3.7.5
jackson -> 2.19.0
httpclient5 -> 5.4.3
mysql-connector -> 9.3.0
maven-surefire -> 3.5.3
project.lombok -> 1.18.38
httpcomponents -> 5.4.4
logback -> 1.5.18
mockito -> 5.17.0
sonar -> 5.1.0.4751
jacoco -> 0.8.13