### PR TITLE
Add support for DNS CAA Emails

### DIFF
--- a/example-app/src/main/java/com/digicert/validation/controller/resource/request/DcvRequestType.java
+++ b/example-app/src/main/java/com/digicert/validation/controller/resource/request/DcvRequestType.java
@@ -3,6 +3,7 @@ package com.digicert.validation.controller.resource.request;
 public enum DcvRequestType {
     EMAIL_DNS_TXT,
     EMAIL_CONSTRUCTED,
+    EMAIL_DNS_CAA,
     DNS_TXT,
     DNS_CNAME,
     DNS_TXT_TOKEN,

--- a/example-app/src/main/java/com/digicert/validation/service/DcvService.java
+++ b/example-app/src/main/java/com/digicert/validation/service/DcvService.java
@@ -66,7 +66,7 @@ public class DcvService {
         try {
             switch (dcvRequest.dcvRequestType()) {
                 case DNS_TXT, DNS_CNAME, DNS_TXT_TOKEN -> createdEntity = submitDnsDomain(dcvRequest);
-                case EMAIL_CONSTRUCTED, EMAIL_DNS_TXT -> createdEntity = submitEmailDomain(dcvRequest);
+                case EMAIL_CONSTRUCTED, EMAIL_DNS_TXT, EMAIL_DNS_CAA -> createdEntity = submitEmailDomain(dcvRequest);
                 case FILE_VALIDATION, FILE_VALIDATION_TOKEN -> createdEntity = submitFileDomain(dcvRequest);
             }
         } catch(DcvException ex){
@@ -85,7 +85,7 @@ public class DcvService {
 
         switch (validateRequest.dcvRequestType) {
             case DNS_TXT, DNS_CNAME, DNS_TXT_TOKEN -> validateDnsDomain(accountId, validationState, validateRequest);
-            case EMAIL_CONSTRUCTED, EMAIL_DNS_TXT ->
+            case EMAIL_CONSTRUCTED, EMAIL_DNS_TXT, EMAIL_DNS_CAA ->
                     validateEmailDomain(validationState, validateRequest);
             case FILE_VALIDATION, FILE_VALIDATION_TOKEN -> validateFileDomain(accountId, validationState, validateRequest);
         }
@@ -214,7 +214,7 @@ public class DcvService {
                     throw new InvalidDcvRequestException("Supplied random value is invalid for domain");
                 }
             }
-            case EMAIL_CONSTRUCTED, EMAIL_DNS_TXT -> {
+            case EMAIL_CONSTRUCTED, EMAIL_DNS_TXT, EMAIL_DNS_CAA -> {
                 if (domainEntity.domainRandomValues.stream().noneMatch(randomValue ->
                         randomValue.randomValue.equals(validateRequest.randomValue) && randomValue.email.equals(validateRequest.emailAddress))) {
                     throw new InvalidDcvRequestException("Supplied email, random value pair are invalid for domain");
@@ -318,6 +318,7 @@ public class DcvService {
         return switch (dcvRequestType) {
             case EMAIL_CONSTRUCTED -> EmailSource.CONSTRUCTED;
             case EMAIL_DNS_TXT -> EmailSource.DNS_TXT;
+            case EMAIL_DNS_CAA -> EmailSource.DNS_CAA;
             default -> throw new InvalidDcvRequestException("Invalid dcvRequestType, must be one of the following"
                     + List.of(DcvRequestType.values()));
         };

--- a/example-app/src/test/java/com/digicert/validation/EmailMethodIT.java
+++ b/example-app/src/test/java/com/digicert/validation/EmailMethodIT.java
@@ -8,6 +8,7 @@ import com.digicert.validation.controller.resource.request.ValidateRequest;
 import com.digicert.validation.controller.resource.response.DcvRequestStatus;
 import com.digicert.validation.controller.resource.response.DomainRandomValueDetails;
 import com.digicert.validation.controller.resource.response.DomainResource;
+import com.digicert.validation.methods.email.prepare.provider.DnsCaaEmailProvider;
 import com.digicert.validation.methods.email.prepare.provider.DnsTxtEmailProvider;
 import com.digicert.validation.utils.DomainUtils;
 import org.junit.jupiter.api.Test;
@@ -86,6 +87,50 @@ class EmailMethodIT {
         // verify domain is showing as valid
         DomainResource verifiedDomain = exampleAppClient.getDomainResource(domainResource.getId());
         assertEquals(DcvRequestStatus.VALID, verifiedDomain.getStatus());
+    }
+
+
+    @Test
+    void verifyEmailDnsCaaSubmitFlow_HappyPath() {
+        // create domain request with email dns caa
+        DcvRequest dcvRequest = createDcvRequest(DomainUtils.getRandomDomainName(2, "com"), DcvRequestType.EMAIL_DNS_CAA);
+        String caaEmail = "caaemail@domain.com";
+
+        // add email as a dns caa record
+        pdnsClient.addCaaRecord(dcvRequest.domain(), List.of(caaEmail, "invalid-email"));
+
+        // submit domain
+        DomainResource domainResource = exampleAppClient.submitDnsDomain(dcvRequest);
+        assertEquals(domainResource.getRandomValueDetails().size(), 1);
+
+        // verify domain is created
+        DomainResource createdDomain = exampleAppClient.getDomainResource(domainResource.getId());
+        validateCreatedDomainData(dcvRequest, createdDomain, 1);
+
+        // build the validation request
+        DomainRandomValueDetails randomValue = createdDomain.getRandomValueDetails().getFirst();
+        ValidateRequest validateRequest = ValidateRequest.builder()
+                .dcvRequestType(dcvRequest.dcvRequestType())
+                .emailAddress(randomValue.getEmail())
+                .randomValue(randomValue.getRandomValue())
+                .domain(dcvRequest.domain())
+                .build();
+
+        // validate the domain
+        exampleAppClient.validateDomain(validateRequest, domainResource.getId());
+
+        // verify domain is showing as valid
+        DomainResource verifiedDomain = exampleAppClient.getDomainResource(domainResource.getId());
+        assertEquals(DcvRequestStatus.VALID, verifiedDomain.getStatus());
+    }
+
+    @Test
+    void verifyEmailDnsCaaSubmitFlow_badRequest_noCaaEmails() {
+        // create domain request with email dns txt
+        DcvRequest dcvRequest = createDcvRequest(DomainUtils.getRandomDomainName(2, "com"), DcvRequestType.EMAIL_DNS_CAA);
+
+        // verify bad request when no caa email is present
+        assertTrue(exampleAppClient.submitDnsDomainExpectingFail(dcvRequest));
     }
 
     @Test

--- a/library/src/main/java/com/digicert/validation/enums/DcvMethod.java
+++ b/library/src/main/java/com/digicert/validation/enums/DcvMethod.java
@@ -61,6 +61,15 @@ public enum DcvMethod {
     BR_3_2_2_4_7("3.2.2.4.7"),
 
     /**
+     * Email to DNS CAA Contact.
+     * <p>
+     * This method involves sending an email to an address specified in a DNS CAA record. The DNS CAA record must be
+     * located at &lt;domain&gt;, and use the contactemail tag. The email will contain a random value that the recipient
+     * can use to confirm control over the domain.
+     */
+    BR_3_2_2_4_13("3.2.2.4.13"),
+
+    /**
      * Email to DNS Txt Contact.
      * <p>
      * This method involves sending an email to an address specified in a DNS TXT record. The DNS TXT record must be

--- a/library/src/main/java/com/digicert/validation/enums/LogEvents.java
+++ b/library/src/main/java/com/digicert/validation/enums/LogEvents.java
@@ -73,6 +73,9 @@ public enum LogEvents {
     /** Log event indicating that no properly formatted DNS TXT records containing a contact were found. */
     NO_DNS_TXT_CONTACT_FOUND,
 
+    /** Log event indicating that no properly formatted DNS CAA records containing a contact email were found. */
+    NO_DNS_CAA_CONTACT_FOUND,
+
     /** Security provider used for calculating hashes was unable to load. The default token validator will not be usable. */
     SECURITY_PROVIDER_LOAD_ERROR,
 

--- a/library/src/main/java/com/digicert/validation/methods/email/EmailValidator.java
+++ b/library/src/main/java/com/digicert/validation/methods/email/EmailValidator.java
@@ -33,6 +33,7 @@ import java.util.stream.Collectors;
  * This class implements Validation for the following methods:
  * <ul>
  *     <li>{@link DcvMethod#BR_3_2_2_4_4}</li>
+ *     <li>{@link DcvMethod#BR_3_2_2_4_13}</li>
  *     <li>{@link DcvMethod#BR_3_2_2_4_14}</li>
  * </ul>
  *
@@ -48,6 +49,15 @@ public class EmailValidator {
      * domain, which can include email addresses used for domain validation.
      */
     private EmailProvider emailDnsTxtProvider;
+
+    /**
+     * The DNS CAA provider for email.
+     * <p>
+     * This provider is responsible for fetching email addresses from DNS CAA records. It is used when the
+     * email source is specified as DNS_CAA. The DNS CAA records contain record information associated with a
+     * domain, which can include email addresses used for domain validation.
+     */
+    private EmailProvider emailDnsCaaProvider;
 
     /**
      * The constructed email provider.
@@ -95,6 +105,7 @@ public class EmailValidator {
      */
     public EmailValidator(DcvContext dcvContext) {
         emailDnsTxtProvider = dcvContext.get(DnsTxtEmailProvider.class);
+        emailDnsCaaProvider = dcvContext.get(DnsCaaEmailProvider.class);
         emailConstructedProvider = new ConstructedEmailProvider();
 
         randomValueGenerator = dcvContext.get(RandomValueGenerator.class);
@@ -110,12 +121,16 @@ public class EmailValidator {
      * without relying on the actual DcvContext.
      *
      * @param emailDnsTxtProvider The DNS TXT provider
+     * @param emailDnsCaaProvider The DNS CAA provider
      * @param emailConstructedProvider The constructed email provider
      */
-    EmailValidator(EmailProvider emailDnsTxtProvider, EmailProvider emailConstructedProvider) {
+    EmailValidator(EmailProvider emailDnsTxtProvider,
+                   EmailProvider emailDnsCaaProvider,
+                   EmailProvider emailConstructedProvider) {
         this(new DcvContext());
 
         this.emailDnsTxtProvider = emailDnsTxtProvider;
+        this.emailDnsCaaProvider = emailDnsCaaProvider;
         this.emailConstructedProvider = emailConstructedProvider;
     }
 
@@ -205,6 +220,7 @@ public class EmailValidator {
         return switch (emailSource) {
             case CONSTRUCTED -> emailConstructedProvider;
             case DNS_TXT -> emailDnsTxtProvider;
+            case DNS_CAA -> emailDnsCaaProvider;
         };
     }
 }

--- a/library/src/main/java/com/digicert/validation/methods/email/prepare/EmailSource.java
+++ b/library/src/main/java/com/digicert/validation/methods/email/prepare/EmailSource.java
@@ -28,6 +28,17 @@ public enum EmailSource {
     CONSTRUCTED(DcvMethod.BR_3_2_2_4_4), // 3.2.2.4.4
 
     /**
+     * The email addresses are found in a DNS CAA record for the domain.
+     * <p>
+     * This source involves querying the DNS CAA records of the domain to find email addresses.
+     * DNS CAA records can contain various types of information, including email addresses for domain validation.
+     * This method is specified under BR 3.2.2.4.13 and provides a flexible way to verify domain ownership through DNS configurations.
+     * </p>
+     * BR 3.2.2.4.13
+     */
+    DNS_CAA(DcvMethod.BR_3_2_2_4_13),
+
+    /**
      * The email addresses are found in a DNS TXT record for the domain.
      * <p>
      * This source involves querying the DNS TXT records of the domain to find email addresses.

--- a/library/src/main/java/com/digicert/validation/methods/email/prepare/provider/DnsCaaEmailProvider.java
+++ b/library/src/main/java/com/digicert/validation/methods/email/prepare/provider/DnsCaaEmailProvider.java
@@ -1,0 +1,80 @@
+package com.digicert.validation.methods.email.prepare.provider;
+
+import com.digicert.validation.DcvContext;
+import com.digicert.validation.client.dns.DnsClient;
+import com.digicert.validation.client.dns.DnsData;
+import com.digicert.validation.enums.DnsType;
+import com.digicert.validation.enums.LogEvents;
+import com.digicert.validation.exceptions.PreparationException;
+import com.digicert.validation.utils.DomainNameUtils;
+import lombok.extern.slf4j.Slf4j;
+import org.xbill.DNS.CAARecord;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * EmailDnsCaaProvider is an implementation of EmailProvider that retrieves email contacts for a domain by querying the
+ * DNS CAA records of the domain.
+ * <p>
+ * This provider is designed to facilitate the process of domain validation by extracting email addresses from DNS CAA records.
+ * The DNS CAA records are filtered using a specific tag defined in the Baseline Requirements (BRs), which ensures that the
+ * email addresses retrieved are intended for validation purposes.
+ */
+@Slf4j
+public class DnsCaaEmailProvider implements EmailProvider {
+
+    /**
+     * This CAA record tag is used to identify the DNS CAA record that contains the email address for validation.
+     * It is defined in the BRs as "contactemail" (section A.1.1).
+     * <p>
+     * The tag "contactemail" is a standardized identifier used in DNS CAA records to denote email addresses
+     * that are specifically set up for domain validation.
+     */
+    public static final String DNS_CAA_EMAIL_TAG = "contactemail";
+
+    /**
+     * The DNS client used to query DNS records.
+     */
+    private final DnsClient dnsClient;
+
+    /**
+     * Constructs a new EmailDnsCaaProvider with the given DcvContext.
+     * <p>
+     * This constructor initializes the DnsCaaEmailProvider with the necessary dependencies and configuration provided by the
+     * DcvContext.
+     *
+     * @param dcvContext context where we can find the needed dependencies and configuration
+     */
+    public DnsCaaEmailProvider(DcvContext dcvContext) {
+        dnsClient = dcvContext.get(DnsClient.class);
+    }
+
+    /**
+     * Retrieves email contacts for the given domain by querying the DNS CAA records of the domain.
+     * <p>
+     * This method performs a DNS query to retrieve emails found in the domain CAA records, filtering the
+     * results to the BR specified "contactemail" tag.
+     *
+     * @param domain the domain to retrieve email contacts for
+     * @return a set of email contacts for the domain
+     * @throws PreparationException if an error occurs while retrieving email contacts for the domain
+     */
+    @Override
+    public Set<String> findEmailsForDomain(String domain) throws PreparationException {
+        DnsData dnsData = dnsClient.getDnsData(List.of(domain), DnsType.CAA);
+
+        Set<String> emails = dnsData.records().stream()
+                .filter(dnsRecord -> ((CAARecord) dnsRecord).getTag().equals(DNS_CAA_EMAIL_TAG))
+                .map(dnsRecord -> ((CAARecord) dnsRecord).getValue())
+                .collect(Collectors.toUnmodifiableSet());
+
+        if (emails.isEmpty()) {
+            log.info("event_id={} domain={} records={}", LogEvents.NO_DNS_CAA_CONTACT_FOUND, domain, dnsData.records().size());
+            throw new PreparationException(dnsData.errors());
+        }
+
+        return emails;
+    }
+}

--- a/library/src/test/java/com/digicert/validation/methods/email/EmailValidatorTest.java
+++ b/library/src/test/java/com/digicert/validation/methods/email/EmailValidatorTest.java
@@ -28,6 +28,7 @@ import static org.mockito.Mockito.*;
 class EmailValidatorTest {
 
     private EmailProvider emailDnsTxtProvider;
+    private EmailProvider emailDnsCaaProvider;
     private EmailProvider emailConstructedProvider;
 
     EmailValidator emailValidator;
@@ -35,9 +36,10 @@ class EmailValidatorTest {
     @BeforeEach
     void setUp() {
         emailDnsTxtProvider = mock(EmailProvider.class);
+        emailDnsCaaProvider = mock(EmailProvider.class);
         emailConstructedProvider = mock(EmailProvider.class);
 
-        emailValidator = new EmailValidator(emailDnsTxtProvider, emailConstructedProvider);
+        emailValidator = new EmailValidator(emailDnsTxtProvider, emailDnsCaaProvider, emailConstructedProvider);
     }
 
     @Test
@@ -47,6 +49,15 @@ class EmailValidatorTest {
         EmailPreparationResponse response = emailValidator.prepare(emailPreparation);
 
         assertEmailPreparationResponse(response, EmailSource.DNS_TXT, emailDnsTxtProvider);
+    }
+
+    @Test
+    void testPrepare_dnsCaaEmailSource() throws DcvException {
+        EmailPreparation emailPreparation = getEmailPreparation(EmailSource.DNS_CAA, emailDnsCaaProvider);
+
+        EmailPreparationResponse response = emailValidator.prepare(emailPreparation);
+
+        assertEmailPreparationResponse(response, EmailSource.DNS_CAA, emailDnsCaaProvider);
     }
 
     @Test

--- a/library/src/test/java/com/digicert/validation/methods/email/prepare/provider/DnsCaaEmailProviderTest.java
+++ b/library/src/test/java/com/digicert/validation/methods/email/prepare/provider/DnsCaaEmailProviderTest.java
@@ -1,0 +1,110 @@
+package com.digicert.validation.methods.email.prepare.provider;
+
+import com.digicert.validation.DcvContext;
+import com.digicert.validation.client.dns.DnsClient;
+import com.digicert.validation.client.dns.DnsData;
+import com.digicert.validation.enums.DcvError;
+import com.digicert.validation.enums.DnsType;
+import com.digicert.validation.exceptions.PreparationException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.xbill.DNS.CAARecord;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class DnsCaaEmailProviderTest {
+
+    private DnsClient dnsClient;
+
+    private DnsCaaEmailProvider dnsCaaEmailProvider;
+
+    @BeforeEach
+    public void setUp() {
+        dnsClient = mock(DnsClient.class);
+
+        DcvContext dcvContext = mock(DcvContext.class);
+        when(dcvContext.get(DnsClient.class)).thenReturn(dnsClient);
+
+        dnsCaaEmailProvider = new DnsCaaEmailProvider(dcvContext);
+    }
+
+    @Test
+    void testFindEmailsForDomainCaa_HappyPath() throws PreparationException {
+        String domain = "example.com";
+        String caaEmail = "dnscaaemail@example.com";
+
+        CAARecord caaRecord = mock(CAARecord.class);
+        when(caaRecord.getTag()).thenReturn(DnsCaaEmailProvider.DNS_CAA_EMAIL_TAG);
+        when(caaRecord.getValue()).thenReturn(caaEmail);
+
+        String host = "some-host";
+        DnsData dnsData = new DnsData(List.of(host), "some-name", DnsType.CAA, List.of(caaRecord),
+                Set.of(), host);
+
+        when(dnsClient.getDnsData(List.of(domain), DnsType.CAA)).thenReturn(dnsData);
+
+        Set<String> emails = dnsCaaEmailProvider.findEmailsForDomain(domain);
+
+        assertTrue(emails.contains(caaEmail), "Expected email not found in the result set");
+        assertEquals(1, emails.size());
+    }
+
+
+    @Test
+    void testFindEmailsForDomainCaa_multipleCaaRecords() throws PreparationException {
+        String domain = "example.com";
+        String caaEmail = "dnscaaemail@example.com";
+
+        CAARecord caaEmailRecord = mock(CAARecord.class);
+        when(caaEmailRecord.getTag()).thenReturn(DnsCaaEmailProvider.DNS_CAA_EMAIL_TAG);
+        when(caaEmailRecord.getValue()).thenReturn(caaEmail);
+
+        CAARecord caaIssueRecord = mock(CAARecord.class);
+        when(caaIssueRecord.getTag()).thenReturn("issue");
+        when(caaIssueRecord.getValue()).thenReturn(domain);
+
+        CAARecord caaIssueWildRecord = mock(CAARecord.class);
+        when(caaIssueWildRecord.getTag()).thenReturn("issueWild");
+        when(caaIssueWildRecord.getValue()).thenReturn(domain);
+
+        String host = "some-host";
+        DnsData dnsData = new DnsData(List.of(host), "some-name", DnsType.CAA, List.of(caaEmailRecord, caaIssueRecord, caaIssueWildRecord),
+                Set.of(), host);
+
+        when(dnsClient.getDnsData(List.of(domain), DnsType.CAA)).thenReturn(dnsData);
+
+        Set<String> emails = dnsCaaEmailProvider.findEmailsForDomain(domain);
+
+        assertTrue(emails.contains(caaEmail), "Expected email not found in the result set");
+        assertEquals(1, emails.size());
+    }
+
+    @Test
+    void testFindEmailsForDomainCaa_throwsPreparationException() {
+        String domain = "example.com";
+        DnsData dnsData = new DnsData(List.of(), domain, DnsType.CAA, List.of(),
+                Set.of(DcvError.DNS_LOOKUP_UNKNOWN_HOST_EXCEPTION), "some-host");
+        when(dnsClient.getDnsData(List.of(domain), DnsType.CAA)).thenReturn(dnsData);
+
+        PreparationException exception = assertThrows(PreparationException.class, () -> dnsCaaEmailProvider.findEmailsForDomain(domain));
+
+        assertTrue(exception.getErrors().contains(DcvError.DNS_LOOKUP_UNKNOWN_HOST_EXCEPTION));
+    }
+
+    @Test
+    void testFindEmailsForDomainCaa_missingDnsData() {
+        String domain = "example.com";
+        DnsData dnsData = new DnsData(List.of(), domain, DnsType.CAA, List.of(),
+                Set.of(DcvError.DNS_LOOKUP_RECORD_NOT_FOUND), "some-host");
+        when(dnsClient.getDnsData(List.of(domain), DnsType.CAA)).thenReturn(dnsData);
+
+        PreparationException exception = assertThrows(PreparationException.class, () -> dnsCaaEmailProvider.findEmailsForDomain(domain));
+
+        assertTrue(exception.getErrors().contains(DcvError.DNS_LOOKUP_RECORD_NOT_FOUND));
+    }
+}


### PR DESCRIPTION
Added new DnsCaaEmailProvider. This provider will query CAA records and use any records found with the 'contactemail' tag at the domain. These emails can be used to validate the domain, and will have a unique email source DNS_CAA.

QA Test case:

- Create a new zone in pdns for the domain you wish to test with
- create a new CAA record in that zone, with the tag 'contactemail' and the value of the email you wish to test with
- Using the example app, submit the new domain for validation with the dcvReuestType 'EMAIL_DNS_CAA'
- verify the email set up in the pdns caa record is returned
- validate the domain using the random value/email pair
- verify domain is shown as valid in example app