### PR TITLE
Update documentation

### DIFF
--- a/README-details.md
+++ b/README-details.md
@@ -241,7 +241,7 @@ DnsValidationResponse response = dnsValidationHandler.validate(request);
 ```
 
 
-### BR: 3.2.2.4.2 / 3.2.2.4.4 / 3.2.2.4.14 - Email to Domain Contact / Constructed Email / DNS TXT Contact
+### BR: 3.2.2.4.4 / 3.2.2.4.13 / 3.2.2.4.14 - Constructed Email / DNS CAA Contact / DNS TXT Contact
 #### EmailPreparationRequest - Email Preparation
 The `EmailPreparationRequest` object is used to prepare the email validation process. This request object is built using the `EmailPreparationRequest.Builder` class, and contains the following fields:
 

--- a/README.md
+++ b/README.md
@@ -34,14 +34,12 @@ Supported Methods
 
 
 ### [Email to DNS CAA Contact](https://github.com/cabforum/servercert/blob/main/docs/BR.md#322413-email-to-dns-caa-contact)
-* The prepare step obtains the email address of the [DNS CAA record email contact](https://github.com/cabforum/servercert/blob/main/docs/BR.md#a11-dns-caa-record-email-contact) (`contactemail` tag).
-  The library does not facilitate sending the random value to the applicant.
+* The prepare step obtains the email address of the [DNS CAA record email contact](https://github.com/cabforum/servercert/blob/main/docs/BR.md#a11-dns-caa-record-email-contact). The library does not facilitate sending the random value to the applicant.
 * This library does not facilitate receiving the random value from the applicant. The validation step can only confirm the appropriate
   data has been collected.
 
 ### [Email to DNS TXT Contact](https://github.com/cabforum/servercert/blob/main/docs/BR.md#322414-email-to-dns-txt-contact)
-* The prepare step obtains the email address of the [DNS TXT record email contact](https://github.com/cabforum/servercert/blob/main/docs/BR.md#a21-dns-txt-record-email-contact).
-  The library does not facilitate sending the random value to the applicant.
+* The prepare step obtains the email address of the [DNS TXT record email contact](https://github.com/cabforum/servercert/blob/main/docs/BR.md#a21-dns-txt-record-email-contact). The library does not facilitate sending the random value to the applicant.
 * This library does not facilitate receiving the random value from the applicant. The validation step can only confirm the appropriate
   data has been collected.
 

--- a/README.md
+++ b/README.md
@@ -20,9 +20,6 @@ objects are used, please refer to the [README-details.md](README-details.md) fil
 Supported Methods
 -----------------
 
-### ~~[Email, Fax, SMS, or Postal Mail to Domain Contact](https://github.com/cabforum/servercert/blob/main/docs/BR.md#32242-email-fax-sms-or-postal-mail-to-domain-contact)~~ (DEPRECATED — Not Supported)
-* **Deprecated.** BR 3.2.2.4.2 (WHOIS-based) is no longer supported by this library.
-* Use BR 3.2.2.4.4 (Constructed Email), BR 3.2.2.4.13 (Email to DNS CAA Contact), or BR 3.2.2.4.14 (Email to DNS TXT Contact) instead.
 
 ### [Constructed Email to Domain Contact](https://github.com/cabforum/servercert/blob/main/docs/BR.md#32244-constructed-email-to-domain-contact)
 * The prepare step generates the possible email addresses to which the random value could be sent. The library does not facilitate
@@ -37,7 +34,7 @@ Supported Methods
 
 
 ### [Email to DNS CAA Contact](https://github.com/cabforum/servercert/blob/main/docs/BR.md#322413-email-to-dns-caa-contact)
-* The prepare step obtains the email address of the DNS CAA contact (`contactemail` in CAA records), using the RFC 8659 Section 3 CAA search algorithm.
+* The prepare step obtains the email address of the [DNS CAA record email contact](https://github.com/cabforum/servercert/blob/main/docs/BR.md#a11-dns-caa-record-email-contact) (`contactemail` tag).
   The library does not facilitate sending the random value to the applicant.
 * This library does not facilitate receiving the random value from the applicant. The validation step can only confirm the appropriate
   data has been collected.

--- a/README.md
+++ b/README.md
@@ -20,11 +20,9 @@ objects are used, please refer to the [README-details.md](README-details.md) fil
 Supported Methods
 -----------------
 
-### [Email, Fax, SMS, or Postal Mail to Domain Contact](https://github.com/cabforum/servercert/blob/main/docs/BR.md#32242-email-fax-sms-or-postal-mail-to-domain-contact)
-* The prepare step obtains contact information for the [domain contact](https://github.com/cabforum/servercert/blob/main/docs/BR.md#161-definitions).
-  The library does not facilitate sending the random value to the applicant.
-* This library does not facilitate receiving the random value from the applicant. The validation step can only confirm the appropriate
-  data has been collected.
+### ~~[Email, Fax, SMS, or Postal Mail to Domain Contact](https://github.com/cabforum/servercert/blob/main/docs/BR.md#32242-email-fax-sms-or-postal-mail-to-domain-contact)~~ (DEPRECATED — Not Supported)
+* **Deprecated.** BR 3.2.2.4.2 (WHOIS-based) is no longer supported by this library.
+* Use BR 3.2.2.4.4 (Constructed Email), BR 3.2.2.4.13 (Email to DNS CAA Contact), or BR 3.2.2.4.14 (Email to DNS TXT Contact) instead.
 
 ### [Constructed Email to Domain Contact](https://github.com/cabforum/servercert/blob/main/docs/BR.md#32244-constructed-email-to-domain-contact)
 * The prepare step generates the possible email addresses to which the random value could be sent. The library does not facilitate
@@ -36,6 +34,13 @@ Supported Methods
 * The prepare step only returns a random value that can be used and the domains that could be used to validate the given FQDN.
 * The validate step will call the DNS servers and obtain the specified record type for the specified domain. It will also check
   with the configurable domain label prefixed. If the random value is found in the record, the DCV can be considered complete.
+
+
+### [Email to DNS CAA Contact](https://github.com/cabforum/servercert/blob/main/docs/BR.md#322413-email-to-dns-caa-contact)
+* The prepare step obtains the email address of the DNS CAA contact (`contactemail` in CAA records), using the RFC 8659 Section 3 CAA search algorithm.
+  The library does not facilitate sending the random value to the applicant.
+* This library does not facilitate receiving the random value from the applicant. The validation step can only confirm the appropriate
+  data has been collected.
 
 ### [Email to DNS TXT Contact](https://github.com/cabforum/servercert/blob/main/docs/BR.md#322414-email-to-dns-txt-contact)
 * The prepare step obtains the email address of the [DNS TXT record email contact](https://github.com/cabforum/servercert/blob/main/docs/BR.md#a21-dns-txt-record-email-contact).

--- a/library/src/main/java/com/digicert/validation/DcvManager.java
+++ b/library/src/main/java/com/digicert/validation/DcvManager.java
@@ -35,10 +35,13 @@ public class DcvManager {
      * This validator assists with email-based domain control validation. It is able to perform DNS lookups
      * to determine usable email addresses for a given domain. It is not able to send out emails.
      * <p>
+     * Note: BR 3.2.2.4.2 (Email, Fax, SMS, or Postal Mail to Domain Contact / WHOIS) is deprecated and
+     * not supported by this library.
+     * <p>
      * Handles
      * <ul>
-     * <li>3.2.2.4.2 Email, Fax, SMS, or Postal Mail to Domain Contact</li>
      * <li>3.2.2.4.4 Constructed Email to Domain Contact</li>
+     * <li>3.2.2.4.13 Email to DNS CAA Contact</li>
      * <li>3.2.2.4.14 Email to DNS TXT Contact</li>
      * </ul>
      */

--- a/library/src/main/java/com/digicert/validation/DcvManager.java
+++ b/library/src/main/java/com/digicert/validation/DcvManager.java
@@ -35,9 +35,6 @@ public class DcvManager {
      * This validator assists with email-based domain control validation. It is able to perform DNS lookups
      * to determine usable email addresses for a given domain. It is not able to send out emails.
      * <p>
-     * Note: BR 3.2.2.4.2 (Email, Fax, SMS, or Postal Mail to Domain Contact / WHOIS) is deprecated and
-     * not supported by this library.
-     * <p>
      * Handles
      * <ul>
      * <li>3.2.2.4.4 Constructed Email to Domain Contact</li>

--- a/library/src/main/java/com/digicert/validation/common/DomainValidationEvidence.java
+++ b/library/src/main/java/com/digicert/validation/common/DomainValidationEvidence.java
@@ -44,7 +44,7 @@ public class DomainValidationEvidence {
      * EMAIL: The email address used for validation.
      * <p>
      * Only populated when the DCV method is an email type otherwise NULL
-     * (BR_3_2_2_4_2 / BR_3_2_2_4_4 / BR_3_2_2_4_14)
+     * (BR_3_2_2_4_4 / BR_3_2_2_4_13 / BR_3_2_2_4_14)
      */
     private final String emailAddress;
 

--- a/library/src/main/java/com/digicert/validation/enums/DcvMethod.java
+++ b/library/src/main/java/com/digicert/validation/enums/DcvMethod.java
@@ -9,7 +9,7 @@ import lombok.Getter;
  * Brief Description of the DCV Methods:
  * <ul>
  *     <li>3.2.2.4.1 -> NOT Allowed</li>
- *     <li>3.2.2.4.2 -> Email (whois) - Not Allowed</li>
+ *     <li>3.2.2.4.2 -> NOT Allowed</li>
  *     <li>3.2.2.4.3 -> Phone - NOT Allowed</li>
  *     <li><b>3.2.2.4.4 -> Email to constructed email address</b></li>
  *     <li>3.2.2.4.5 -> NOT Allowed</li>

--- a/library/src/main/java/com/digicert/validation/enums/DcvMethod.java
+++ b/library/src/main/java/com/digicert/validation/enums/DcvMethod.java
@@ -9,7 +9,8 @@ import lombok.Getter;
  * Brief Description of the DCV Methods:
  * <ul>
  *     <li>3.2.2.4.1 -> NOT Allowed</li>
- *     <li>3.2.2.4.2 -> Email (whois) - Not Allowed</li>
+ *     <li>3.2.2.4.2 -> Email, Fax, SMS, or Postal Mail to Domain Contact (WHOIS) -
+ *     <b>Deprecated and removed from this library</b></li>
  *     <li>3.2.2.4.3 -> Phone - NOT Allowed</li>
  *     <li><b>3.2.2.4.4 -> Email to constructed email address</b></li>
  *     <li>3.2.2.4.5 -> NOT Allowed</li>
@@ -20,7 +21,7 @@ import lombok.Getter;
  *     <li>3.2.2.4.10 -> NOT Allowed</li>
  *     <li>3.2.2.4.11 -> NOT Allowed</li>
  *     <li>3.2.2.4.12 -> Validating applicant as a Domain Contact - Not Supported</li>
- *     <li>3.2.2.4.13 -> Email to DNS CAA Contact - Not Supported</li>
+ *     <li><b>3.2.2.4.13 -> Email to DNS CAA Contact</b></li>
  *     <li><b>3.2.2.4.14 -> Email to DNS TXT Contact</b></li>
  *     <li>3.2.2.4.15 / 16 / 17 -> Phone Contact - Not Supported</li>
  *     <li><b>3.2.2.4.18 -> File Validation</b></li>

--- a/library/src/main/java/com/digicert/validation/enums/DcvMethod.java
+++ b/library/src/main/java/com/digicert/validation/enums/DcvMethod.java
@@ -9,8 +9,7 @@ import lombok.Getter;
  * Brief Description of the DCV Methods:
  * <ul>
  *     <li>3.2.2.4.1 -> NOT Allowed</li>
- *     <li>3.2.2.4.2 -> Email, Fax, SMS, or Postal Mail to Domain Contact (WHOIS) -
- *     <b>Deprecated and removed from this library</b></li>
+ *     <li>3.2.2.4.2 -> Email (whois) - Not Allowed</li>
  *     <li>3.2.2.4.3 -> Phone - NOT Allowed</li>
  *     <li><b>3.2.2.4.4 -> Email to constructed email address</b></li>
  *     <li>3.2.2.4.5 -> NOT Allowed</li>

--- a/library/src/main/java/com/digicert/validation/methods/email/prepare/provider/DnsCaaEmailProvider.java
+++ b/library/src/main/java/com/digicert/validation/methods/email/prepare/provider/DnsCaaEmailProvider.java
@@ -20,8 +20,8 @@ import java.util.stream.Collectors;
  * DNS CAA records of the domain.
  * <p>
  * This provider is designed to facilitate the process of domain validation by extracting email addresses from DNS CAA records.
- * The DNS CAA records are filtered using a specific tag defined in the Baseline Requirements (BRs), which ensures that the
- * email addresses retrieved are intended for validation purposes.
+ * The DNS CAA records are filtered using the {@code contactemail} tag defined in the Baseline Requirements (BRs, section A.1.1),
+ * which ensures that the email addresses retrieved are intended for validation purposes.
  */
 @Slf4j
 public class DnsCaaEmailProvider implements EmailProvider {


### PR DESCRIPTION
## Summary
Updates open-source documentation and Javadocs to accurately reflect the current set of supported DCV methods:

Adds BR 3.2.2.4.13 (Email to DNS CAA Contact) as a supported method across all documentation.
Marks BR 3.2.2.4.2 (Email, Fax, SMS, or Postal Mail to Domain Contact) as deprecated and not supported by this library.