### PR TITLE
add IP address support for file-based DCV (BR 3.2.2.5.1)

### DIFF
--- a/library/src/main/java/com/digicert/validation/enums/DcvMethod.java
+++ b/library/src/main/java/com/digicert/validation/enums/DcvMethod.java
@@ -16,6 +16,7 @@ import lombok.Getter;
  *     <li>3.2.2.4.6 -> NOT Allowed</li>
  *     <li><b>3.2.2.4.7 - DNS Change</b></li>
  *     <li>3.2.2.4.8 -> IP Address - Not Supported</li>
+ *     <li><b>3.2.2.5.1 -> Agreed-Upon Change to Website (IP Address)</b></li>
  *     <li>3.2.2.4.9 -> NOT Allowed</li>
  *     <li>3.2.2.4.10 -> NOT Allowed</li>
  *     <li>3.2.2.4.11 -> NOT Allowed</li>
@@ -86,6 +87,18 @@ public enum DcvMethod {
      * request token confirms control over the FQDN.
      */
     BR_3_2_2_4_18("3.2.2.4.18"),
+
+    /**
+     * Agreed-Upon Change to Website — IP Address.
+     * <p>
+     * This method is used for IP address DCV. The file validation mechanism is identical to
+     * {@link #BR_3_2_2_4_18} (same {@code /.well-known/pki-validation/} path, same challenge types),
+     * but is recorded under BR section 3.2.2.5.1 for IP address subjects.
+     * <p>
+     * Note: BR 3.2.2.4.8 (IP Address) has been deprecated in the current Baseline Requirements.
+     * This method supersedes it.
+     */
+    BR_3_2_2_5_1("3.2.2.5.1"),
 
     /**
      * ACME HTTP Challenge.

--- a/library/src/main/java/com/digicert/validation/methods/file/FileValidator.java
+++ b/library/src/main/java/com/digicert/validation/methods/file/FileValidator.java
@@ -29,8 +29,9 @@ import java.time.Instant;
 /**
  * FileValidator is a class that provides methods to prepare and validate files for domain validation.
  * <p>
- * This class implements Validation for {@link DcvMethod#BR_3_2_2_4_18} method. It is responsible for handling the preparation and validation
- * processes required for file-based domain control validation (DCV).
+ * This class implements Validation for {@link DcvMethod#BR_3_2_2_4_18} and {@link DcvMethod#BR_3_2_2_5_1} methods.
+ * It is responsible for handling the preparation and validation processes required for file-based domain control
+ * validation (DCV) for both domain names and IP addresses.
  */
 @Slf4j
 public class FileValidator {
@@ -113,11 +114,14 @@ public class FileValidator {
         verifyFilePreparation(preparationRequest);
 
         // Create and return the preparation response
+        DcvMethod dcvMethod = DomainNameUtils.isIpAddress(preparationRequest.domain())
+                ? DcvMethod.BR_3_2_2_5_1
+                : DcvMethod.BR_3_2_2_4_18;
         FilePreparationResponse.FilePreparationResponseBuilder responseBuilder = FilePreparationResponse.builder()
                 .domain(preparationRequest.domain())
                 .challengeType(preparationRequest.challengeType())
                 .fileLocation(getFileUrl(preparationRequest.domain(), preparationRequest.filename()))
-                .validationState(new ValidationState(preparationRequest.domain(), Instant.now(), DcvMethod.BR_3_2_2_4_18));
+                .validationState(new ValidationState(preparationRequest.domain(), Instant.now(), dcvMethod));
 
         if (preparationRequest.challengeType() == ChallengeType.RANDOM_VALUE) {
             responseBuilder.randomValue(randomValueGenerator.generateRandomString());
@@ -197,8 +201,11 @@ public class FileValidator {
      */
     void verifyFileValidationRequest(FileValidationRequest fileValidationRequest) throws DcvException {
 
-        domainNameUtils.validateDomainName(fileValidationRequest.getDomain());
-        StateValidationUtils.verifyValidationState(fileValidationRequest.getValidationState(), DcvMethod.BR_3_2_2_4_18);
+        domainNameUtils.validateDomainOrIpAddress(fileValidationRequest.getDomain());
+        DcvMethod expectedMethod = DomainNameUtils.isIpAddress(fileValidationRequest.getDomain())
+                ? DcvMethod.BR_3_2_2_5_1
+                : DcvMethod.BR_3_2_2_4_18;
+        StateValidationUtils.verifyValidationState(fileValidationRequest.getValidationState(), expectedMethod);
 
         switch (fileValidationRequest.getChallengeType()) {
             case RANDOM_VALUE -> {
@@ -224,7 +231,7 @@ public class FileValidator {
      * @throws DcvException if the request is invalid. {@link InputException} when missing required fields.
      */
     private void verifyFilePreparation(FilePreparationRequest filePreparationRequest) throws DcvException, IllegalArgumentException {
-        domainNameUtils.validateDomainName(filePreparationRequest.domain());
+        domainNameUtils.validateDomainOrIpAddress(filePreparationRequest.domain());
 
         if (filePreparationRequest.challengeType() == null) {
             throw new InputException(DcvError.CHALLENGE_TYPE_REQUIRED);
@@ -234,7 +241,7 @@ public class FileValidator {
             FilenameUtils.validateFilename(filePreparationRequest.filename());
         }
 
-        if (filePreparationRequest.domain().startsWith("*.")) {
+        if (!DomainNameUtils.isIpAddress(filePreparationRequest.domain()) && filePreparationRequest.domain().startsWith("*.")) {
             throw new InputException(DcvError.DOMAIN_INVALID_WILDCARD_NOT_ALLOWED);
         }
     }

--- a/library/src/main/java/com/digicert/validation/methods/file/validate/FileValidationHandler.java
+++ b/library/src/main/java/com/digicert/validation/methods/file/validate/FileValidationHandler.java
@@ -222,11 +222,12 @@ public class FileValidationHandler {
      * @return the list of file URLs
      */
     public List<String> getFileUrls(FileValidationRequest fileValidationRequest) {
+        String host = formatHostForUrl(fileValidationRequest.getDomain());
         String domainPath;
         if (StringUtils.isNotBlank(fileValidationRequest.getFilename())) {
-            domainPath = fileValidationRequest.getDomain() + FILE_PATH + fileValidationRequest.getFilename();
+            domainPath = host + FILE_PATH + fileValidationRequest.getFilename();
         } else {
-            domainPath = fileValidationRequest.getDomain() + FILE_PATH + defaultFileValidationFilename;
+            domainPath = host + FILE_PATH + defaultFileValidationFilename;
         }
         if (fileValidationCheckHttps) {
             if (fileValidationCheckHttpsFirst) {
@@ -238,5 +239,22 @@ public class FileValidationHandler {
         else {
             return List.of("http://" + domainPath);
         }
+    }
+
+    /**
+     * Formats the host portion of a URL.
+     * <p>
+     * IPv6 addresses must be enclosed in brackets per RFC 2732 when used in URLs
+     * (e.g., {@code http://[2001:db8::1]/.well-known/...}). IPv4 addresses and
+     * domain names are returned unchanged.
+     *
+     * @param domainOrIp the domain name or IP address
+     * @return the host string suitable for use in a URL
+     */
+    private static String formatHostForUrl(String domainOrIp) {
+        if (domainOrIp.contains(":")) {  // IPv6 addresses always contain ":"
+            return "[" + domainOrIp + "]";
+        }
+        return domainOrIp;
     }
 }

--- a/library/src/main/java/com/digicert/validation/utils/DomainNameUtils.java
+++ b/library/src/main/java/com/digicert/validation/utils/DomainNameUtils.java
@@ -9,6 +9,8 @@ import com.ibm.icu.text.IDNA;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 
+import org.bouncycastle.util.IPAddress;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -279,6 +281,43 @@ public class DomainNameUtils {
         } catch (IllegalArgumentException e) {
             throw new InputException(DcvError.DOMAIN_INVALID_INCORRECT_NAME_PATTERN, e);
         }
+    }
+
+    /**
+     * Checks if the given value is an IP address (IPv4 or IPv6).
+     * <p>
+     * Uses BouncyCastle {@link IPAddress#isValid(String)} for consistent, pure-parser validation
+     * with no DNS resolution side-effects.
+     *
+     * @param value the value to check
+     * @return true if the value is a valid IPv4 or IPv6 address, false otherwise
+     */
+    public static boolean isIpAddress(String value) {
+        if (StringUtils.isEmpty(value)) return false;
+        return IPAddress.isValid(value);
+    }
+
+    /**
+     * Validates the given value as either a domain name or an IP address.
+     * <p>
+     * If the value is a valid IP address (per {@link #isIpAddress(String)}), this method returns
+     * without further checks. Range checks (e.g. private or reserved ranges) are the
+     * responsibility of the caller.
+     * <p>
+     * If the value does not look like an IP address, it is validated as a domain name via
+     * {@link #validateDomainName(String)}.
+     *
+     * @param value the domain name or IP address to validate
+     * @throws InputException if the value is empty, not a valid IP address, or not a valid domain name
+     */
+    public void validateDomainOrIpAddress(String value) throws InputException {
+        if (StringUtils.isEmpty(value)) {
+            throw new InputException(DcvError.DOMAIN_REQUIRED);
+        }
+        if (isIpAddress(value)) {
+            return;
+        }
+        validateDomainName(value);
     }
 
     /**

--- a/library/src/test/java/com/digicert/validation/methods/file/FileValidatorTest.java
+++ b/library/src/test/java/com/digicert/validation/methods/file/FileValidatorTest.java
@@ -52,6 +52,64 @@ class FileValidatorTest {
     }
 
     @Test
+    void testVerifyFileValidationRequest_ipv4_withBR_3_2_2_5_1_shouldSucceed() {
+        // Arrange
+        FileValidationRequest request = FileValidationRequest.builder()
+                .domain("1.2.3.4")
+                .randomValue(defaultRandomValue)
+                .challengeType(ChallengeType.RANDOM_VALUE)
+                .validationState(new ValidationState("1.2.3.4", Instant.now(), DcvMethod.BR_3_2_2_5_1))
+                .build();
+
+        // Act & Assert
+        assertDoesNotThrow(() -> fileValidator.verifyFileValidationRequest(request));
+    }
+
+    @Test
+    void testVerifyFileValidationRequest_ipv6_withBR_3_2_2_5_1_shouldSucceed() {
+        // Arrange
+        FileValidationRequest request = FileValidationRequest.builder()
+                .domain("2001:db8::1")
+                .randomValue(defaultRandomValue)
+                .challengeType(ChallengeType.RANDOM_VALUE)
+                .validationState(new ValidationState("2001:db8::1", Instant.now(), DcvMethod.BR_3_2_2_5_1))
+                .build();
+
+        // Act & Assert
+        assertDoesNotThrow(() -> fileValidator.verifyFileValidationRequest(request));
+    }
+
+    @Test
+    void testVerifyFileValidationRequest_ipv4_withBR_3_2_2_4_18_shouldThrowInvalidDcvMethod() {
+        // Arrange - IP address but wrong DCV method (domain method)
+        FileValidationRequest request = FileValidationRequest.builder()
+                .domain("1.2.3.4")
+                .randomValue(defaultRandomValue)
+                .challengeType(ChallengeType.RANDOM_VALUE)
+                .validationState(new ValidationState("1.2.3.4", Instant.now(), DcvMethod.BR_3_2_2_4_18))
+                .build();
+
+        // Act & Assert
+        InputException exception = assertThrows(InputException.class, () -> fileValidator.verifyFileValidationRequest(request));
+        assertTrue(exception.getErrors().contains(DcvError.INVALID_DCV_METHOD));
+    }
+
+    @Test
+    void testVerifyFileValidationRequest_domain_withBR_3_2_2_5_1_shouldThrowInvalidDcvMethod() {
+        // Arrange - domain name but wrong DCV method (IP method)
+        FileValidationRequest request = FileValidationRequest.builder()
+                .domain("example.com")
+                .randomValue(defaultRandomValue)
+                .challengeType(ChallengeType.RANDOM_VALUE)
+                .validationState(new ValidationState("example.com", Instant.now(), DcvMethod.BR_3_2_2_5_1))
+                .build();
+
+        // Act & Assert
+        InputException exception = assertThrows(InputException.class, () -> fileValidator.verifyFileValidationRequest(request));
+        assertTrue(exception.getErrors().contains(DcvError.INVALID_DCV_METHOD));
+    }
+
+    @Test
     void testVerifyFileValidationRequest_InvalidDomain() {
         // Arrange
         FileValidationRequest request = getRandomValueFileValidationRequest()
@@ -111,6 +169,42 @@ class FileValidatorTest {
         FilePreparationRequest filePreparationRequest = new FilePreparationRequest("example.com");
         FilePreparationResponse response = fileValidator.prepare(filePreparationRequest);
         assertEquals("example.com", response.getDomain());
+    }
+
+    @Test
+    void prepare_withIpv4Address_shouldUseBR_3_2_2_5_1Method() throws DcvException {
+        // Arrange
+        FilePreparationRequest request = new FilePreparationRequest("1.2.3.4");
+
+        // Act
+        FilePreparationResponse response = fileValidator.prepare(request);
+
+        // Assert
+        assertEquals(DcvMethod.BR_3_2_2_5_1, response.getValidationState().dcvMethod());
+    }
+
+    @Test
+    void prepare_withIpv6Address_shouldUseBR_3_2_2_5_1Method() throws DcvException {
+        // Arrange
+        FilePreparationRequest request = new FilePreparationRequest("2001:db8::1");
+
+        // Act
+        FilePreparationResponse response = fileValidator.prepare(request);
+
+        // Assert
+        assertEquals(DcvMethod.BR_3_2_2_5_1, response.getValidationState().dcvMethod());
+    }
+
+    @Test
+    void prepare_withDomainName_shouldUseBR_3_2_2_4_18Method() throws DcvException {
+        // Arrange
+        FilePreparationRequest request = new FilePreparationRequest("example.com");
+
+        // Act
+        FilePreparationResponse response = fileValidator.prepare(request);
+
+        // Assert
+        assertEquals(DcvMethod.BR_3_2_2_4_18, response.getValidationState().dcvMethod());
     }
 
     @Test

--- a/library/src/test/java/com/digicert/validation/methods/file/validate/FileValidationHandlerTest.java
+++ b/library/src/test/java/com/digicert/validation/methods/file/validate/FileValidationHandlerTest.java
@@ -109,6 +109,64 @@ class FileValidationHandlerTest {
     }
 
     @Test
+    void testGetFileUrls_ipv4_noHttps() {
+        // Arrange
+        DcvConfiguration dcvConfiguration = new DcvConfiguration.DcvConfigurationBuilder().fileValidationCheckHttps(false).build();
+        initializeMocks(dcvConfiguration);
+        FileValidationRequest request = getRandomValueFileValidationRequestBuilder()
+                .domain("1.2.3.4")
+                .build();
+        // Act
+        List<String> fileUrls = fileValidationHandler.getFileUrls(request);
+        // Assert
+        assertEquals(1, fileUrls.size());
+        assertEquals("http://1.2.3.4/.well-known/pki-validation/fileauth.txt", fileUrls.get(0));
+    }
+
+    @Test
+    void testGetFileUrls_ipv6_bracketWrapped() {
+        // Arrange
+        DcvConfiguration dcvConfiguration = new DcvConfiguration.DcvConfigurationBuilder().fileValidationCheckHttps(false).build();
+        initializeMocks(dcvConfiguration);
+        FileValidationRequest request = getRandomValueFileValidationRequestBuilder()
+                .domain("2001:db8::1")
+                .build();
+        // Act
+        List<String> fileUrls = fileValidationHandler.getFileUrls(request);
+        // Assert
+        assertEquals(1, fileUrls.size());
+        assertEquals("http://[2001:db8::1]/.well-known/pki-validation/fileauth.txt", fileUrls.get(0));
+    }
+
+    @Test
+    void testGetFileUrls_ipv6_fullAddress_bracketWrapped() {
+        // Arrange
+        DcvConfiguration dcvConfiguration = new DcvConfiguration.DcvConfigurationBuilder().fileValidationCheckHttps(false).build();
+        initializeMocks(dcvConfiguration);
+        FileValidationRequest request = getRandomValueFileValidationRequestBuilder()
+                .domain("2001:0db8:85a3:0000:0000:8a2e:0370:7334")
+                .build();
+        // Act
+        List<String> fileUrls = fileValidationHandler.getFileUrls(request);
+        // Assert
+        assertEquals(1, fileUrls.size());
+        assertEquals("http://[2001:0db8:85a3:0000:0000:8a2e:0370:7334]/.well-known/pki-validation/fileauth.txt", fileUrls.get(0));
+    }
+
+    @Test
+    void testGetFileUrls_domain_notBracketWrapped() {
+        // Arrange
+        DcvConfiguration dcvConfiguration = new DcvConfiguration.DcvConfigurationBuilder().fileValidationCheckHttps(false).build();
+        initializeMocks(dcvConfiguration);
+        // Act
+        List<String> fileUrls = fileValidationHandler.getFileUrls(getRandomValueFileValidationRequest());
+        // Assert
+        assertEquals(1, fileUrls.size());
+        assertEquals("http://example.com/.well-known/pki-validation/fileauth.txt", fileUrls.get(0));
+        assertFalse(fileUrls.get(0).contains("["));
+    }
+
+    @Test
     void testValidate_validResponse() {
         // Arrange
         when(mpicFileService.getMpicFileDetails(anyList(), eq("randomValue"))).thenReturn(getMpicFileDetails(true, null, 200, "randomValue"));

--- a/library/src/test/java/com/digicert/validation/utils/DomainNameUtilsTest.java
+++ b/library/src/test/java/com/digicert/validation/utils/DomainNameUtilsTest.java
@@ -351,7 +351,11 @@ class DomainNameUtilsTest {
                 Arguments.of("256.0.0.1",              false),
                 // Empty / null
                 Arguments.of("",                       false),
-                Arguments.of(null,                     false)
+                Arguments.of(null,                     false),
+                // already bracketed IPv6 - gets rejected
+                Arguments.of("[2001:db8::1]",          false),
+                // host:port format - gets rejected
+                Arguments.of("example.com:8080",          false)
         );
     }
 

--- a/library/src/test/java/com/digicert/validation/utils/DomainNameUtilsTest.java
+++ b/library/src/test/java/com/digicert/validation/utils/DomainNameUtilsTest.java
@@ -326,6 +326,90 @@ class DomainNameUtilsTest {
         assertEquals(isValid, DomainNameUtils.isValidEmailAddress(email));
     }
 
+    // -----------------------------------------------------------------------
+    // isIpAddress
+    // -----------------------------------------------------------------------
+
+    static Stream<Arguments> provideIsIpAddressTestData() {
+        return Stream.of(
+                // IPv4 — should be recognised as IP
+                Arguments.of("1.2.3.4",               true),
+                Arguments.of("192.168.1.1",            true),
+                Arguments.of("0.0.0.0",                true),
+                Arguments.of("255.255.255.255",        true),
+                // IPv6 — should be recognised as IP (contains ":")
+                Arguments.of("2001:db8::1",            true),
+                Arguments.of("2001:0db8:85a3:0000:0000:8a2e:0370:7334", true),
+                Arguments.of("::1",                    true),
+                Arguments.of("::ffff:1.2.3.4",         true),
+                // Domain names — should NOT be recognised as IP
+                Arguments.of("example.com",            false),
+                Arguments.of("sub.example.com",        false),
+                // Strings that have letters mixed with IPv4-like dots
+                Arguments.of("a12.0.0.1",              false),
+                // Out-of-range IPv4 — BouncyCastle rejects these as invalid
+                Arguments.of("256.0.0.1",              false),
+                // Empty / null
+                Arguments.of("",                       false),
+                Arguments.of(null,                     false)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideIsIpAddressTestData")
+    void isIpAddress(String value, boolean expected) {
+        assertEquals(expected, DomainNameUtils.isIpAddress(value));
+    }
+
+    // -----------------------------------------------------------------------
+    // validateDomainOrIpAddress
+    // -----------------------------------------------------------------------
+
+    static Stream<Arguments> provideValidateDomainOrIpAddress_valid() {
+        return Stream.of(
+                // Valid domain names — delegates to validateDomainName
+                Arguments.of("example.com"),
+                Arguments.of("sub.example.com"),
+                // Valid IPv4
+                Arguments.of("1.2.3.4"),
+                Arguments.of("192.168.1.1"),
+                Arguments.of("203.0.113.42"),
+                // Valid IPv6
+                Arguments.of("2001:db8::1"),
+                Arguments.of("2001:0db8:85a3:0000:0000:8a2e:0370:7334"),
+                Arguments.of("::1"),
+                Arguments.of("::ffff:192.0.2.1")
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideValidateDomainOrIpAddress_valid")
+    void validateDomainOrIpAddress_valid(String value) {
+        assertDoesNotThrow(() -> domainNameUtils.validateDomainOrIpAddress(value));
+    }
+
+    static Stream<Arguments> provideValidateDomainOrIpAddress_invalid() {
+        return Stream.of(
+                Arguments.of(null,        DcvError.DOMAIN_REQUIRED),
+                Arguments.of("",          DcvError.DOMAIN_REQUIRED),
+                // Invalid IPv4 (out of range) — IPAddress.isValid() returns false, falls through to domain validation
+                Arguments.of("256.0.0.1", DcvError.DOMAIN_INVALID_INCORRECT_NAME_PATTERN),
+                // Invalid IPv6 (multiple shorthand notations) — IPAddress.isValid() returns false, falls through to domain validation
+                Arguments.of("2001::85a3::7334", DcvError.DOMAIN_INVALID_INCORRECT_NAME_PATTERN),
+                // Invalid domain name
+                Arguments.of("example.invalid", DcvError.DOMAIN_INVALID_NOT_UNDER_PUBLIC_SUFFIX)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideValidateDomainOrIpAddress_invalid")
+    void validateDomainOrIpAddress_invalid(String value, DcvError expectedError) {
+        InputException exception = assertThrows(InputException.class,
+                () -> domainNameUtils.validateDomainOrIpAddress(value));
+        assertTrue(exception.getErrors().contains(expectedError),
+                "expected error: " + expectedError + ", got: " + exception.getErrors());
+    }
+
     private Stream<Arguments> emailProvider() {
         return Stream.of(
                 Arguments.of("dnstxt@email.com", true),


### PR DESCRIPTION
## Summary
Extends the file-based DCV flow to support IP address subjects, as
required by BR 3.2.2.5.1.
## Changes
### `DcvMethod`
- Added `BR_3_2_2_5_1` enum value for IP address file validation.
- Updated Javadoc to note `BR_3_2_2_4_8` is deprecated and superseded
  by `BR_3_2_2_5_1`.
### `DomainNameUtils`
- Added `isIpAddress(String)` — uses BouncyCastle `IPAddress.isValid()`
  for consistent, pure-parser IP detection (no DNS resolution
  side-effects). 
- Added `validateDomainOrIpAddress(String)` — short-circuits to an IP
  check for IP addresses, falls through to `validateDomainName()` for
  domain names.
### `FileValidator`
- `verifyFilePreparation()` and `verifyFileValidationRequest()` now call
  `validateDomainOrIpAddress()` instead of `validateDomainName()`.
- Wildcard check is skipped for IP addresses.
- Both `prepare()` and `verifyFileValidationRequest()` select
  `BR_3_2_2_5_1` for IP subjects and `BR_3_2_2_4_18` for domain
  subjects, and enforce that the `ValidationState` carries the correct
  method.
### `FileValidationHandler`
- `getFileUrls()` now wraps IPv6 addresses in `[...]` per RFC 2732
  before constructing HTTP URLs.
## Tests
- `DomainNameUtilsTest` — parameterised tests for `isIpAddress()` and
  `validateDomainOrIpAddress()` covering valid/invalid IPv4, IPv6, and
  domain names.
- `FileValidationHandlerTest` — URL construction tests for IPv4, IPv6
  (bracket-wrapped), and domain names.
- `FileValidatorTest` — tests for `prepare()` DCV method selection and
  `verifyFileValidationRequest()` method enforcement for IP and domain
  subjects.