### PR TITLE
add IP address support for file-based DCV (BR 3.2.2.5.1)

### DIFF
--- a/example-app/src/test/java/com/digicert/validation/IpAddressFileMethodIT.java
+++ b/example-app/src/test/java/com/digicert/validation/IpAddressFileMethodIT.java
@@ -1,0 +1,139 @@
+package com.digicert.validation;
+
+import com.digicert.validation.client.ExampleAppClient;
+import com.digicert.validation.config.AllowReservedIpDcvConfiguration;
+import com.digicert.validation.controller.resource.request.DcvRequest;
+import com.digicert.validation.controller.resource.request.DcvRequestType;
+import com.digicert.validation.controller.resource.request.ValidateRequest;
+import com.digicert.validation.controller.resource.response.DcvRequestStatus;
+import com.digicert.validation.controller.resource.response.DomainResource;
+import com.digicert.validation.utils.FileUtils;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Integration tests for IP address file validation (BR 3.2.2.5.1) via the DCV library.
+ * <p>
+ * These tests verify that the file validation method works correctly when the subject is an
+ * IP address rather than a domain name. All tests use {@link AllowReservedIpDcvConfiguration}
+ * so that the local Docker nginx ({@code 127.0.0.1}) can serve the validation file.
+ * <p>
+ * Rejection tests for reserved/private IP addresses (when {@code allowReservedIpAddresses=false})
+ * are in {@link IpAddressFileRejectionIT}.
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureWebTestClient
+@Import(AllowReservedIpDcvConfiguration.class)
+class IpAddressFileMethodIT {
+
+    @Autowired
+    private ExampleAppClient exampleAppClient;
+
+    private final Long defaultAccountId = 1234L;
+
+    // -----------------------------------------------------------------------
+    // Happy-path tests — allowReservedIpAddresses=true via @Import
+    // -----------------------------------------------------------------------
+
+    /**
+     * Verifies that file validation succeeds when the subject is a loopback IPv4 address
+     * ({@code 127.0.0.1}) and the library is configured to allow reserved IP addresses.
+     * <p>
+     * The nginx Docker container serves files at {@code 127.0.0.1}, so this test validates
+     * the full end-to-end flow for IP address subjects using the default filename.
+     */
+    @Test
+    void verifyFileValidation_ipv4Address_happyDayFlow() throws IOException {
+        String ipAddress = "127.0.0.1";
+        DcvRequest dcvRequest = new DcvRequest(ipAddress, defaultAccountId, DcvRequestType.FILE_VALIDATION);
+        DomainResource createdDomain = exampleAppClient.submitDnsDomain(dcvRequest);
+
+        assertCreatedDomain(createdDomain, dcvRequest);
+
+        // Write the random value to the default file path served by nginx
+        String randomValue = createdDomain.getRandomValueDetails().getFirst().getRandomValue();
+        FileUtils.writeFileAuthFileWithContent("fileauth.txt", randomValue);
+
+        exampleAppClient.validateDomain(createValidateRequest(createdDomain, "fileauth.txt"), createdDomain.getId());
+
+        DomainResource verifiedDomain = exampleAppClient.getDomainResource(createdDomain.getId());
+        assertEquals(DcvRequestStatus.VALID, verifiedDomain.getStatus());
+    }
+
+    /**
+     * Verifies that file validation succeeds for an IPv4 address subject when a custom
+     * filename is specified in the prepare request.
+     */
+    @Test
+    void verifyFileValidation_ipv4Address_customFilename() throws IOException {
+        String ipAddress = "127.0.0.1";
+        DcvRequest dcvRequest = new DcvRequest(ipAddress, "ip-custom-file", defaultAccountId, DcvRequestType.FILE_VALIDATION);
+        DomainResource createdDomain = exampleAppClient.submitDnsDomain(dcvRequest);
+
+        assertCreatedDomain(createdDomain, dcvRequest);
+
+        String randomValue = createdDomain.getRandomValueDetails().getFirst().getRandomValue();
+        FileUtils.writeFileAuthFileWithContent("ip-custom-file.txt", randomValue);
+
+        exampleAppClient.validateDomain(createValidateRequest(createdDomain, "ip-custom-file.txt"), createdDomain.getId());
+
+        DomainResource verifiedDomain = exampleAppClient.getDomainResource(createdDomain.getId());
+        assertEquals(DcvRequestStatus.VALID, verifiedDomain.getStatus());
+    }
+
+    /**
+     * Verifies that file validation succeeds when the subject is a loopback IPv4 address
+     * and the validate request passes a custom filename that differs from the default.
+     */
+    @Test
+    void verifyFileValidation_ipv4Address_useDefaultFilename() throws IOException {
+        String ipAddress = "127.0.0.1";
+        DcvRequest dcvRequest = new DcvRequest(ipAddress, defaultAccountId, DcvRequestType.FILE_VALIDATION);
+        DomainResource createdDomain = exampleAppClient.submitDnsDomain(dcvRequest);
+
+        assertCreatedDomain(createdDomain, dcvRequest);
+
+        String randomValue = createdDomain.getRandomValueDetails().getFirst().getRandomValue();
+        FileUtils.writeFileAuthFileWithContent("fileauth.txt", randomValue);
+
+        // Pass null filename — should fall back to the library's default ("fileauth.txt")
+        exampleAppClient.validateDomain(createValidateRequest(createdDomain, null), createdDomain.getId());
+
+        DomainResource verifiedDomain = exampleAppClient.getDomainResource(createdDomain.getId());
+        assertEquals(DcvRequestStatus.VALID, verifiedDomain.getStatus());
+    }
+
+    // -----------------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------------
+
+    private static void assertCreatedDomain(DomainResource createdDomain, DcvRequest dcvRequest) {
+        assertNotNull(createdDomain);
+        assertNotEquals(0, createdDomain.getId());
+        assertEquals(dcvRequest.domain(), createdDomain.getDomainName());
+        assertEquals(dcvRequest.accountId(), createdDomain.getAccountId());
+        assertEquals(dcvRequest.dcvRequestType(), createdDomain.getDcvType());
+        assertEquals(DcvRequestStatus.PENDING, createdDomain.getStatus());
+        assertEquals(1, createdDomain.getRandomValueDetails().size());
+        createdDomain.getRandomValueDetails().forEach(detail -> {
+            assertNotNull(detail.getRandomValue());
+            assertNull(detail.getEmail());
+        });
+    }
+
+    private static ValidateRequest createValidateRequest(DomainResource createdDomain, String filename) {
+        return ValidateRequest.builder()
+                .dcvRequestType(DcvRequestType.FILE_VALIDATION)
+                .filename(filename)
+                .randomValue(createdDomain.getRandomValueDetails().getFirst().getRandomValue())
+                .domain(createdDomain.getDomainName())
+                .build();
+    }
+}

--- a/example-app/src/test/java/com/digicert/validation/IpAddressFileRejectionIT.java
+++ b/example-app/src/test/java/com/digicert/validation/IpAddressFileRejectionIT.java
@@ -1,0 +1,58 @@
+package com.digicert.validation;
+
+import com.digicert.validation.client.ExampleAppClient;
+import com.digicert.validation.controller.resource.request.DcvRequest;
+import com.digicert.validation.controller.resource.request.DcvRequestType;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Integration tests that verify reserved and private IP addresses are rejected by the
+ * DCV library when {@code allowReservedIpAddresses} is {@code false} (the default).
+ * <p>
+ * This class uses the production {@link ExampleDCVConfiguration} — no
+ * {@code AllowReservedIpDcvConfiguration} is imported — so the library enforces the
+ * CA/Browser Forum Baseline Requirements check that rejects private/reserved IP space.
+ * <p>
+ * A submission of any reserved IP address must return a non-2xx HTTP response (HTTP 400).
+ *
+ * @see IpAddressFileMethodIT for happy-path IP address file validation tests
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureWebTestClient
+class IpAddressFileRejectionIT {
+
+    @Autowired
+    private ExampleAppClient exampleAppClient;
+
+    private static final Long defaultAccountId = 1234L;
+
+    @ParameterizedTest(name = "{0} is rejected")
+    @MethodSource("provideReservedIpAddresses")
+    void verifyFileValidation_reservedIpAddress_isRejected(String description, String ipAddress) {
+        DcvRequest dcvRequest = new DcvRequest(ipAddress, defaultAccountId, DcvRequestType.FILE_VALIDATION);
+        assertTrue(exampleAppClient.submitDnsDomainExpectingFail(dcvRequest));
+    }
+
+    private static Stream<Arguments> provideReservedIpAddresses() {
+        return Stream.of(
+                Arguments.of("RFC 1918 class-A private IPv4 (10.0.0.1)",    "10.0.0.1"),
+                Arguments.of("RFC 1918 class-B private IPv4 (172.16.0.1)",  "172.16.0.1"),
+                Arguments.of("RFC 1918 class-C private IPv4 (192.168.1.1)", "192.168.1.1"),
+                Arguments.of("loopback IPv4 (127.0.0.1)",                   "127.0.0.1"),
+                Arguments.of("link-local IPv4 (169.254.1.1)",               "169.254.1.1"),
+                Arguments.of("multicast IPv4 (224.0.0.1)",                  "224.0.0.1"),
+                Arguments.of("loopback IPv6 (::1)",                         "::1"),
+                Arguments.of("link-local IPv6 (fe80::1)",                   "fe80::1"),
+                Arguments.of("ULA IPv6 (fc00::1)",                          "fc00::1")
+        );
+    }
+}

--- a/example-app/src/test/java/com/digicert/validation/config/AllowReservedIpDcvConfiguration.java
+++ b/example-app/src/test/java/com/digicert/validation/config/AllowReservedIpDcvConfiguration.java
@@ -1,0 +1,43 @@
+package com.digicert.validation.config;
+
+import com.digicert.validation.DcvConfiguration;
+import com.digicert.validation.DcvManager;
+import com.digicert.validation.mpic.MpicClientImpl;
+import com.digicert.validation.psl.CustomPslOverrideSupplier;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+
+import java.util.List;
+
+/**
+ * Test-only Spring configuration that overrides the production {@link com.digicert.validation.ExampleDCVConfiguration}
+ * DcvManager bean with one that has {@code allowReservedIpAddresses=true}.
+ * <p>
+ * This is required for integration tests that exercise IP address validation against the local Docker
+ * infrastructure (nginx serving files at {@code 127.0.0.1}), where the validation target necessarily
+ * uses private/loopback IP space.
+ * <p>
+ * <strong>WARNING: This configuration must never be used in production.</strong>
+ */
+@TestConfiguration
+public class AllowReservedIpDcvConfiguration {
+
+    @Bean
+    @Primary
+    DcvManager allowReservedIpDcvManager(CustomPslOverrideSupplier customPslOverrideSupplier,
+                                         MpicClientImpl mpicClientImpl) {
+        DcvConfiguration dcvConfiguration = new DcvConfiguration.DcvConfigurationBuilder()
+                .dnsServers(List.of("localhost:10000"))
+                .pslOverrideSupplier(customPslOverrideSupplier)
+                .mpicClientInterface(mpicClientImpl)
+                // Allow reserved IPs so that the local Docker nginx (127.0.0.1) can be used as a
+                // validation target in integration tests. Must never be set true in production.
+                .allowReservedIpAddresses(true)
+                .build();
+
+        return new DcvManager.Builder()
+                .withDcvConfiguration(dcvConfiguration)
+                .build();
+    }
+}

--- a/library/src/main/java/com/digicert/validation/DcvConfiguration.java
+++ b/library/src/main/java/com/digicert/validation/DcvConfiguration.java
@@ -166,6 +166,19 @@ public class DcvConfiguration {
      */
     private Level logLevelForDcvErrors = Level.WARN;
 
+    /**
+     * Flag to allow reserved/private IP addresses to pass validation without being rejected.
+     * <p>
+     * By default, validation rejects private (RFC 1918) and reserved IP addresses with
+     * {@link com.digicert.validation.enums.DcvError#IP_ADDRESS_RESERVED}. When this flag is
+     * {@code true}, that check is skipped and reserved IPs are treated as valid.
+     * <p>
+     * <strong>WARNING: This flag must never be set to {@code true} in production environments.</strong>
+     * It exists solely to support non-production test environments where validation targets
+     * (e.g., local Docker containers) use private IP address space.
+     */
+    private boolean allowReservedIpAddresses = false;
+
     /** Private constructor to prevent instantiation. */
     private DcvConfiguration() {
         // Private constructor to prevent instantiation
@@ -578,6 +591,25 @@ public class DcvConfiguration {
          */
         public DcvConfigurationBuilder logLevelForDcvErrors(Level logLevelForDcvErrors) {
             dcvConfiguration.setLogLevelForDcvErrors(logLevelForDcvErrors);
+            return this;
+        }
+
+        /**
+         * Allow reserved and private IP addresses to bypass the reserved IP check during validation.
+         * <p>
+         * <strong>WARNING: This method is intended for use in non-production test environments only.</strong>
+         * Enabling this in production would allow validation against private/reserved IP space, which
+         * violates CA/Browser Forum Baseline Requirements.
+         * <p>
+         * Use this only in acceptance or integration test configurations where validation targets
+         * reside on private IP addresses (e.g., local Docker infrastructure).
+         *
+         * @apiNote This method exists solely for test environment support. Do not call it in production code.
+         * @param allowReservedIpAddresses {@code true} to skip the reserved IP check; {@code false} (default) to enforce it
+         * @return the builder instance
+         */
+        public DcvConfigurationBuilder allowReservedIpAddresses(boolean allowReservedIpAddresses) {
+            dcvConfiguration.setAllowReservedIpAddresses(allowReservedIpAddresses);
             return this;
         }
 

--- a/library/src/main/java/com/digicert/validation/DcvConfiguration.java
+++ b/library/src/main/java/com/digicert/validation/DcvConfiguration.java
@@ -3,6 +3,7 @@ package com.digicert.validation;
 import com.digicert.validation.challenges.BasicRandomValueValidator;
 import com.digicert.validation.challenges.RandomValueValidator;
 import com.digicert.validation.challenges.RequestTokenValidator;
+import com.digicert.validation.enums.LogEvents;
 import com.digicert.validation.mpic.MpicClientInterface;
 import com.digicert.validation.mpic.NoopMpicClientImpl;
 import com.digicert.validation.psl.PslDataProvider;
@@ -15,6 +16,8 @@ import com.digicert.validation.utils.PslOverrideSupplier;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.Setter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.slf4j.event.Level;
 
 import java.util.List;
@@ -176,6 +179,12 @@ public class DcvConfiguration {
      * <strong>WARNING: This flag must never be set to {@code true} in production environments.</strong>
      * It exists solely to support non-production test environments where validation targets
      * (e.g., local Docker containers) use private IP address space.
+     * <p>
+     * The bypass takes effect inside
+     * {@link com.digicert.validation.utils.DomainNameUtils#validateDomainOrIpAddress(String)}:
+     * when {@code true}, {@code DomainNameUtils.isPrivateOrReservedIpAddress} returns {@code false}
+     * even for reserved IPs, allowing them through validation instead of raising
+     * {@link com.digicert.validation.enums.DcvError#IP_ADDRESS_RESERVED}.
      */
     private boolean allowReservedIpAddresses = false;
 
@@ -186,6 +195,8 @@ public class DcvConfiguration {
 
     /** Builder class for Domain Control Validation (DCV) configuration. */
     public static class DcvConfigurationBuilder {
+
+        private static final Logger log = LoggerFactory.getLogger(DcvConfigurationBuilder.class);
 
         /** The DcvConfiguration instance to be built. */
         private final DcvConfiguration dcvConfiguration = new DcvConfiguration();
@@ -623,6 +634,11 @@ public class DcvConfiguration {
          */
         public DcvConfiguration build() {
             PslDataProvider.getInstance().loadDefaultData();
+            if (dcvConfiguration.isAllowReservedIpAddresses()) {
+                log.error("event_id={} message=\"allowReservedIpAddresses=true is BR-prohibited in production; " +
+                        "enable only in non-production test environments\"",
+                        LogEvents.RESERVED_IP_CHECK_BYPASSED);
+            }
             return dcvConfiguration;
         }
     }

--- a/library/src/main/java/com/digicert/validation/client/file/CustomDnsResolver.java
+++ b/library/src/main/java/com/digicert/validation/client/file/CustomDnsResolver.java
@@ -4,7 +4,6 @@ import com.digicert.validation.DcvContext;
 import com.digicert.validation.client.dns.DnsClient;
 import com.digicert.validation.enums.DnsType;
 import org.apache.hc.client5.http.SystemDefaultDnsResolver;
-import org.xbill.DNS.ARecord;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
@@ -36,17 +35,31 @@ public class CustomDnsResolver extends SystemDefaultDnsResolver {
      * Resolves the given host name to an array of InetAddress objects using the DnsClient.
      * <p>
      * This method overrides the resolve method of the SystemDefaultDnsResolver to provide custom DNS
-     * resolution logic. It uses the DnsClient to perform the A record DNS lookup.
-     * The A records are then converted to InetAddress objects, which are returned as the
-     * result. If the DNS lookup fails or an error occurs, an UnknownHostException is thrown with a detailed
-     * error message.
+     * resolution logic. If the host is already an IP address literal (IPv4 or IPv6), it is resolved
+     * directly via the system resolver without performing a DNS lookup — DNS A-record queries for bare
+     * IP addresses are meaningless and will always fail. The check is performed by attempting to parse
+     * the host string with {@link InetAddress#getByName(String)} and comparing the result back to the
+     * original string; if they match, the input is an IP literal.
+     * <p>
+     * For domain names, the DnsClient performs an A-record lookup using the CA-managed DNS servers
+     * required by the CA/Browser Forum Baseline Requirements.
      *
-     * @param host The host name to resolve.
-     * @return An array of InetAddress objects for the given host name.
+     * @param host The host name (or IP address literal) to resolve.
+     * @return An array of InetAddress objects for the given host.
      * @throws UnknownHostException If the host name cannot be resolved.
      */
     @Override
     public InetAddress[] resolve(String host) throws UnknownHostException {
+        // IP address literals need no DNS lookup — delegate directly to the system resolver.
+        try {
+            InetAddress addr = InetAddress.getByName(host);
+            if (addr.getHostAddress().equals(host)) {
+                return super.resolve(host);
+            }
+        } catch (UnknownHostException ignored) {
+            // not an IP literal; fall through to DNS lookup
+        }
+
         try {
 
             return dnsClient.getDnsData(List.of(host), DnsType.A)

--- a/library/src/main/java/com/digicert/validation/client/file/CustomDnsResolver.java
+++ b/library/src/main/java/com/digicert/validation/client/file/CustomDnsResolver.java
@@ -4,6 +4,7 @@ import com.digicert.validation.DcvContext;
 import com.digicert.validation.client.dns.DnsClient;
 import com.digicert.validation.enums.DnsType;
 import org.apache.hc.client5.http.SystemDefaultDnsResolver;
+import org.bouncycastle.util.IPAddress;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
@@ -37,9 +38,9 @@ public class CustomDnsResolver extends SystemDefaultDnsResolver {
      * This method overrides the resolve method of the SystemDefaultDnsResolver to provide custom DNS
      * resolution logic. If the host is already an IP address literal (IPv4 or IPv6), it is resolved
      * directly via the system resolver without performing a DNS lookup — DNS A-record queries for bare
-     * IP addresses are meaningless and will always fail. The check is performed by attempting to parse
-     * the host string with {@link InetAddress#getByName(String)} and comparing the result back to the
-     * original string; if they match, the input is an IP literal.
+     * IP addresses are meaningless and will always fail. The check is performed using
+     * {@link IPAddress#isValid(String)}, a pure-parser check that performs no DNS queries and handles
+     * both IPv4 and IPv6 literals correctly regardless of canonical form.
      * <p>
      * For domain names, the DnsClient performs an A-record lookup using the CA-managed DNS servers
      * required by the CA/Browser Forum Baseline Requirements.
@@ -51,13 +52,8 @@ public class CustomDnsResolver extends SystemDefaultDnsResolver {
     @Override
     public InetAddress[] resolve(String host) throws UnknownHostException {
         // IP address literals need no DNS lookup — delegate directly to the system resolver.
-        try {
-            InetAddress addr = InetAddress.getByName(host);
-            if (addr.getHostAddress().equals(host)) {
-                return super.resolve(host);
-            }
-        } catch (UnknownHostException ignored) {
-            // not an IP literal; fall through to DNS lookup
+        if (IPAddress.isValid(host)) {
+            return super.resolve(host);
         }
 
         try {

--- a/library/src/main/java/com/digicert/validation/enums/DcvError.java
+++ b/library/src/main/java/com/digicert/validation/enums/DcvError.java
@@ -378,6 +378,27 @@ public enum DcvError {
      */
     IP_ADDRESS_RESERVED,
 
+    /**
+     * Error indicating that a challenge value (random value or request token) appears in the
+     * caller-supplied filename, which would expose the secret in the GET request URL.
+     * <p>
+     * The CA/Browser Forum Baseline Requirements state that the challenge material
+     * "MUST NOT appear in the request." If the filename embeds the random value or a
+     * derived request token, that secret travels in the URL on the wire and in server
+     * access logs regardless of the file's contents, violating this requirement.
+     * <p>
+     * This error is raised:
+     * <ul>
+     *   <li><em>Pre-fetch</em> (in {@code FileValidator.verifyFileValidationRequest}) when a
+     *       random value is detected in the filename — before any HTTP request is made.</li>
+     *   <li><em>Post-fetch</em> (in {@code FileValidationHandler.buildFileValidationResponse})
+     *       when the located challenge value (random value or request token) is found in the
+     *       filename — the final gate that also covers request tokens whose value is only
+     *       known after the fetch.</li>
+     * </ul>
+     */
+    CHALLENGE_VALUE_IN_REQUEST_NOT_ALLOWED,
+
     /** Error indicating that the challenge type is invalid. */
     INVALID_CHALLENGE_TYPE;
 

--- a/library/src/main/java/com/digicert/validation/enums/DcvError.java
+++ b/library/src/main/java/com/digicert/validation/enums/DcvError.java
@@ -369,6 +369,15 @@ public enum DcvError {
     /** Error indicating an issue when creating the ACME DNS key */
     ACME_DNS_KEY_ERROR,
 
+    /**
+     * Error indicating that the IP address is in a private or reserved range and cannot be used for DCV.
+     * <p>
+     * Private ranges (RFC 1918): 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16.
+     * Reserved ranges include loopback, link-local, multicast, and other IANA-reserved blocks.
+     * For IPv6, only Global Unicast addresses (2000::/3) are permitted.
+     */
+    IP_ADDRESS_RESERVED,
+
     /** Error indicating that the challenge type is invalid. */
     INVALID_CHALLENGE_TYPE;
 

--- a/library/src/main/java/com/digicert/validation/enums/DcvMethod.java
+++ b/library/src/main/java/com/digicert/validation/enums/DcvMethod.java
@@ -16,6 +16,7 @@ import lombok.Getter;
  *     <li>3.2.2.4.6 -> NOT Allowed</li>
  *     <li><b>3.2.2.4.7 - DNS Change</b></li>
  *     <li>3.2.2.4.8 -> IP Address - Not Supported</li>
+ *     <li><b>3.2.2.5.1 -> Agreed-Upon Change to Website (IP Address)</b></li>
  *     <li>3.2.2.4.9 -> NOT Allowed</li>
  *     <li>3.2.2.4.10 -> NOT Allowed</li>
  *     <li>3.2.2.4.11 -> NOT Allowed</li>
@@ -87,6 +88,18 @@ public enum DcvMethod {
      * request token confirms control over the FQDN.
      */
     BR_3_2_2_4_18("3.2.2.4.18"),
+
+    /**
+     * Agreed-Upon Change to Website — IP Address.
+     * <p>
+     * This method is used for IP address DCV. The file validation mechanism is identical to
+     * {@link #BR_3_2_2_4_18} (same {@code /.well-known/pki-validation/} path, same challenge types),
+     * but is recorded under BR section 3.2.2.5.1 for IP address subjects.
+     * <p>
+     * Note: BR 3.2.2.4.8 (IP Address) has been deprecated in the current Baseline Requirements.
+     * This method supersedes it.
+     */
+    BR_3_2_2_5_1("3.2.2.5.1"),
 
     /**
      * ACME HTTP Challenge.

--- a/library/src/main/java/com/digicert/validation/enums/LogEvents.java
+++ b/library/src/main/java/com/digicert/validation/enums/LogEvents.java
@@ -89,7 +89,10 @@ public enum LogEvents {
     SECURITY_PROVIDER_LOAD_ERROR,
 
     /** Log event indicating a failure in creating the SSL context. Should not be reachable and would indicate a Java library mismatch. */
-    SSL_CONTEXT_CREATION_ERROR;
+    SSL_CONTEXT_CREATION_ERROR,
+
+    /** Log event indicating that a reserved/private IP address was allowed to bypass the reserved IP check due to the allowReservedIpAddresses configuration flag. */
+    RESERVED_IP_CHECK_BYPASSED;
 
     /**
      * Returns the lowercase string representation of the event.

--- a/library/src/main/java/com/digicert/validation/methods/file/FileValidator.java
+++ b/library/src/main/java/com/digicert/validation/methods/file/FileValidator.java
@@ -194,10 +194,17 @@ public class FileValidator {
      * This method validates the values in the provided {@link FileValidationRequest}. It checks the domain, validation
      * state, and challenge type, ensuring that all required fields are present and valid. For random values, it
      * verifies the entropy and expiration. For request tokens, it checks the presence of the request token data.
+     * <p>
+     * A caller-supplied filename is also validated for format, and — for random-value challenges — rejected
+     * pre-fetch if the random value appears in the filename. Embedding the secret in the URL would expose it
+     * on the wire and in server access logs regardless of the file's contents, violating the BR requirement
+     * that the challenge material must not appear in the request.
      *
      * @param fileValidationRequest The validation verification request
-     * @throws DcvException If entropy level is insufficient, the random value has expired, or the request token data
-     * is missing.
+     * @throws DcvException If entropy level is insufficient, the random value has expired, the request token data
+     * is missing, or a challenge value is found in the caller-supplied filename.
+     * @throws IllegalArgumentException If the caller-supplied filename contains invalid characters or exceeds the
+     * maximum length.
      */
     void verifyFileValidationRequest(FileValidationRequest fileValidationRequest) throws DcvException {
 
@@ -207,10 +214,23 @@ public class FileValidator {
                 : DcvMethod.BR_3_2_2_4_18;
         StateValidationUtils.verifyValidationState(fileValidationRequest.getValidationState(), expectedMethod);
 
+        // Validate the caller-supplied filename format (mirrors the check done in verifyFilePreparation).
+        if (StringUtils.isNotBlank(fileValidationRequest.getFilename())) {
+            FilenameUtils.validateFilename(fileValidationRequest.getFilename());
+        }
+
         switch (fileValidationRequest.getChallengeType()) {
             case RANDOM_VALUE -> {
                 Instant instant = fileValidationRequest.getValidationState().prepareTime();
                 randomValueVerifier.verifyRandomValue(fileValidationRequest.getRandomValue(), instant);
+                // Pre-fetch guard: reject before any HTTP request is made if the random value is
+                // embedded in the filename. The secret would travel in the URL on the wire
+                // regardless of the HTTP response, violating the BR "must not appear in the request" rule.
+                if (StringUtils.isNotBlank(fileValidationRequest.getFilename())
+                        && StringUtils.isNotBlank(fileValidationRequest.getRandomValue())
+                        && fileValidationRequest.getFilename().contains(fileValidationRequest.getRandomValue())) {
+                    throw new InputException(DcvError.CHALLENGE_VALUE_IN_REQUEST_NOT_ALLOWED);
+                }
             }
             case REQUEST_TOKEN -> {
                 if (fileValidationRequest.getRequestTokenData() == null) {

--- a/library/src/main/java/com/digicert/validation/methods/file/FileValidator.java
+++ b/library/src/main/java/com/digicert/validation/methods/file/FileValidator.java
@@ -29,8 +29,9 @@ import java.time.Instant;
 /**
  * FileValidator is a class that provides methods to prepare and validate files for domain validation.
  * <p>
- * This class implements Validation for {@link DcvMethod#BR_3_2_2_4_18} method. It is responsible for handling the preparation and validation
- * processes required for file-based domain control validation (DCV).
+ * This class implements Validation for {@link DcvMethod#BR_3_2_2_4_18} and {@link DcvMethod#BR_3_2_2_5_1} methods.
+ * It is responsible for handling the preparation and validation processes required for file-based domain control
+ * validation (DCV) for both domain names and IP addresses.
  */
 @Slf4j
 public class FileValidator {
@@ -113,11 +114,14 @@ public class FileValidator {
         verifyFilePreparation(preparationRequest);
 
         // Create and return the preparation response
+        DcvMethod dcvMethod = DomainNameUtils.isIpAddress(preparationRequest.domain())
+                ? DcvMethod.BR_3_2_2_5_1
+                : DcvMethod.BR_3_2_2_4_18;
         FilePreparationResponse.FilePreparationResponseBuilder responseBuilder = FilePreparationResponse.builder()
                 .domain(preparationRequest.domain())
                 .challengeType(preparationRequest.challengeType())
                 .fileLocation(getFileUrl(preparationRequest.domain(), preparationRequest.filename()))
-                .validationState(new ValidationState(preparationRequest.domain(), Instant.now(), DcvMethod.BR_3_2_2_4_18));
+                .validationState(new ValidationState(preparationRequest.domain(), Instant.now(), dcvMethod));
 
         if (preparationRequest.challengeType() == ChallengeType.RANDOM_VALUE) {
             responseBuilder.randomValue(randomValueGenerator.generateRandomString());
@@ -197,8 +201,11 @@ public class FileValidator {
      */
     void verifyFileValidationRequest(FileValidationRequest fileValidationRequest) throws DcvException {
 
-        domainNameUtils.validateDomainName(fileValidationRequest.getDomain());
-        StateValidationUtils.verifyValidationState(fileValidationRequest.getValidationState(), DcvMethod.BR_3_2_2_4_18);
+        domainNameUtils.validateDomainOrIpAddress(fileValidationRequest.getDomain());
+        DcvMethod expectedMethod = DomainNameUtils.isIpAddress(fileValidationRequest.getDomain())
+                ? DcvMethod.BR_3_2_2_5_1
+                : DcvMethod.BR_3_2_2_4_18;
+        StateValidationUtils.verifyValidationState(fileValidationRequest.getValidationState(), expectedMethod);
 
         switch (fileValidationRequest.getChallengeType()) {
             case RANDOM_VALUE -> {
@@ -225,7 +232,7 @@ public class FileValidator {
      * @throws DcvException if the request is invalid. {@link InputException} when missing required fields.
      */
     private void verifyFilePreparation(FilePreparationRequest filePreparationRequest) throws DcvException, IllegalArgumentException {
-        domainNameUtils.validateDomainName(filePreparationRequest.domain());
+        domainNameUtils.validateDomainOrIpAddress(filePreparationRequest.domain());
 
         if (filePreparationRequest.challengeType() == null) {
             throw new InputException(DcvError.CHALLENGE_TYPE_REQUIRED);

--- a/library/src/main/java/com/digicert/validation/methods/file/validate/FileValidationHandler.java
+++ b/library/src/main/java/com/digicert/validation/methods/file/validate/FileValidationHandler.java
@@ -12,6 +12,7 @@ import com.digicert.validation.mpic.api.AgentStatus;
 import com.digicert.validation.mpic.api.file.PrimaryFileResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
+import org.bouncycastle.util.IPAddress;
 
 import java.util.List;
 import java.util.Optional;
@@ -217,11 +218,12 @@ public class FileValidationHandler {
      * @return the list of file URLs
      */
     public List<String> getFileUrls(FileValidationRequest fileValidationRequest) {
+        String host = formatHostForUrl(fileValidationRequest.getDomain());
         String domainPath;
         if (StringUtils.isNotBlank(fileValidationRequest.getFilename())) {
-            domainPath = fileValidationRequest.getDomain() + FILE_PATH + fileValidationRequest.getFilename();
+            domainPath = host + FILE_PATH + fileValidationRequest.getFilename();
         } else {
-            domainPath = fileValidationRequest.getDomain() + FILE_PATH + defaultFileValidationFilename;
+            domainPath = host + FILE_PATH + defaultFileValidationFilename;
         }
         if (fileValidationCheckHttps) {
             if (fileValidationCheckHttpsFirst) {
@@ -233,5 +235,22 @@ public class FileValidationHandler {
         else {
             return List.of("http://" + domainPath);
         }
+    }
+
+    /**
+     * Formats the host portion of a URL.
+     * <p>
+     * IPv6 addresses must be enclosed in brackets per RFC 2732 when used in URLs
+     * (e.g., {@code http://[2001:db8::1]/.well-known/...}). IPv4 addresses and
+     * domain names are returned unchanged.
+     *
+     * @param domainOrIp the domain name or IP address
+     * @return the host string suitable for use in a URL
+     */
+    private static String formatHostForUrl(String domainOrIp) {
+        if (IPAddress.isValidIPv6(domainOrIp)) {
+            return "[" + domainOrIp + "]";
+        }
+        return domainOrIp;
     }
 }

--- a/library/src/main/java/com/digicert/validation/methods/file/validate/FileValidationHandler.java
+++ b/library/src/main/java/com/digicert/validation/methods/file/validate/FileValidationHandler.java
@@ -178,6 +178,23 @@ public class FileValidationHandler {
             validRequestToken = challengeResponse.challengeValue().orElse(null);
         }
 
+        // Final gate: if the located challenge value is present in the caller-supplied filename the
+        // secret was embedded in the GET request URL (on the wire and in access logs), which violates
+        // the BR requirement that challenge material must not appear in the request.
+        // This catches request tokens (whose value is only known post-fetch) and redundantly
+        // guards random values alongside the pre-fetch check in FileValidator.verifyFileValidationRequest.
+        if (challengeResponse.challengeValue().isPresent()
+                && StringUtils.isNotBlank(validationRequest.getFilename())
+                && validationRequest.getFilename().contains(challengeResponse.challengeValue().get())) {
+            return FileValidationResponse.builder()
+                    .isValid(false)
+                    .domain(validationRequest.getDomain())
+                    .fileUrl(fileUrl)
+                    .challengeType(challengeType)
+                    .errors(Set.of(DcvError.CHALLENGE_VALUE_IN_REQUEST_NOT_ALLOWED))
+                    .build();
+        }
+
         return FileValidationResponse.builder()
                 .isValid(challengeResponse.challengeValue().isPresent())
                 .mpicDetails(mpicDetails)

--- a/library/src/main/java/com/digicert/validation/utils/DomainNameUtils.java
+++ b/library/src/main/java/com/digicert/validation/utils/DomainNameUtils.java
@@ -372,7 +372,7 @@ public class DomainNameUtils {
     private boolean isPrivateOrReservedIpAddress(String ip) {
         boolean reserved = IPAddress.isValidIPv4(ip) ? isPrivateOrReservedIpv4(ip) : !isPublicIPv6(ip);
         if (reserved && allowReservedIpAddresses) {
-            log.warn("event_id={} ip_address={} message=\"Reserved IP check bypassed - ensure this is running in a test environment only\"",
+            log.error("event_id={} ip_address={} message=\"Reserved IP check bypassed - ensure this is running in a test environment only\"",
                     LogEvents.RESERVED_IP_CHECK_BYPASSED, ip);
             return false;
         }
@@ -430,17 +430,37 @@ public class DomainNameUtils {
     }
 
     /**
-     * Returns true if the IPv6 address is publicly routable (Global Unicast, {@code 2000::/3}).
-     * Only the Global Unicast range is considered a valid public address for DCV purposes.
-     * All other ranges (loopback ::1, link-local fe80::/10, ULA fc00::/7, etc.) are rejected.
+     * Returns true if the IPv6 address is publicly routable (Global Unicast, {@code 2000::/3})
+     * and is not an IANA special-purpose block reserved within that range.
+     * <p>
+     * Passes the Global Unicast guard ({@code 2000::/3}, first 3 bits {@code 001}) and then
+     * rejects the following IANA-reserved sub-ranges (mirroring the IPv4 TEST-NET / reserved
+     * block treatment):
+     * <ul>
+     *   <li>{@code 2001:db8::/32} — documentation prefix (RFC 3849)</li>
+     *   <li>{@code 2001::/23} — IETF Protocol Assignments, covering Teredo ({@code 2001::/32}),
+     *       benchmarking ({@code 2001:2::/48}), ORCHID ({@code 2001:10::/28}),
+     *       and ORCHID v2 ({@code 2001:20::/28})</li>
+     * </ul>
+     * All other ranges (loopback {@code ::1}, link-local {@code fe80::/10},
+     * ULA {@code fc00::/7}, etc.) are also rejected because they fall outside {@code 2000::/3}.
      */
     private static boolean isPublicIPv6(String ip) {
         try {
             InetAddress addr = InetAddress.getByName(ip);
-            // 2000::/3 — first 3 bits must be 001 (first byte & 0xE0 == 0x20)
             byte[] bytes = addr.getAddress();
             if (bytes.length != 16) return false; // not IPv6
-            return (bytes[0] & 0xE0) == 0x20;
+            // Must be in Global Unicast range 2000::/3 (first 3 bits = 001)
+            if ((bytes[0] & 0xE0) != 0x20) return false;
+            // Reject 2001:db8::/32 — documentation prefix (RFC 3849), not a real routable address.
+            // Equivalent to IPv4 TEST-NET-1/2/3 rejection.
+            if (bytes[0] == 0x20 && bytes[1] == 0x01
+                    && bytes[2] == 0x0d && bytes[3] == (byte) 0xb8) return false;
+            // Reject 2001::/23 — IETF Protocol Assignments (covers Teredo 2001::/32,
+            // benchmarking 2001:2::/48, ORCHID 2001:10::/28, ORCHID v2 2001:20::/28).
+            // The /23 mask means bytes[0]==0x20, bytes[1]==0x01, top-7 bits of bytes[2]==0x00.
+            if (bytes[0] == 0x20 && bytes[1] == 0x01 && (bytes[2] & 0xFE) == 0x00) return false;
+            return true;
         } catch (UnknownHostException e) {
             return false;
         }

--- a/library/src/main/java/com/digicert/validation/utils/DomainNameUtils.java
+++ b/library/src/main/java/com/digicert/validation/utils/DomainNameUtils.java
@@ -96,7 +96,7 @@ public class DomainNameUtils {
     /**
      * Whether to allow reserved/private IP addresses to bypass the reserved IP check.
      * <p>
-     * Sourced from {@link com.digicert.validation.DcvConfiguration#isAllowReservedIpAddresses()}.
+     * Sourced from {@link com.digicert.validation.DcvConfiguration.DcvConfigurationBuilder#allowReservedIpAddresses(boolean)}.
      * Must only be {@code true} in non-production test environments.
      */
     private final boolean allowReservedIpAddresses;
@@ -108,8 +108,7 @@ public class DomainNameUtils {
      */
     public DomainNameUtils(DcvContext dcvContext) {
         this.pslOverrideSupplier = dcvContext.get(PslOverrideSupplier.class);
-        DcvConfiguration config = dcvContext.getDcvConfiguration();
-        this.allowReservedIpAddresses = config != null && config.isAllowReservedIpAddresses();
+        this.allowReservedIpAddresses = dcvContext.getDcvConfiguration().isAllowReservedIpAddresses();
     }
 
     /**

--- a/library/src/main/java/com/digicert/validation/utils/DomainNameUtils.java
+++ b/library/src/main/java/com/digicert/validation/utils/DomainNameUtils.java
@@ -1,5 +1,6 @@
 package com.digicert.validation.utils;
 
+import com.digicert.validation.DcvConfiguration;
 import com.digicert.validation.DcvContext;
 import com.digicert.validation.enums.DcvError;
 import com.digicert.validation.enums.LogEvents;
@@ -8,9 +9,13 @@ import com.digicert.validation.psl.DcvDomainName;
 import com.ibm.icu.text.IDNA;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
+import org.bouncycastle.util.IPAddress;
 
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.regex.Pattern;
 
@@ -89,12 +94,22 @@ public class DomainNameUtils {
     private final PslOverrideSupplier pslOverrideSupplier;
 
     /**
+     * Whether to allow reserved/private IP addresses to bypass the reserved IP check.
+     * <p>
+     * Sourced from {@link com.digicert.validation.DcvConfiguration#isAllowReservedIpAddresses()}.
+     * Must only be {@code true} in non-production test environments.
+     */
+    private final boolean allowReservedIpAddresses;
+
+    /**
      * Constructs a new DomainNameUtils with the specified DcvContext.
      *
      * @param dcvContext context where we can find the needed dependencies and configuration
      */
     public DomainNameUtils(DcvContext dcvContext) {
         this.pslOverrideSupplier = dcvContext.get(PslOverrideSupplier.class);
+        DcvConfiguration config = dcvContext.getDcvConfiguration();
+        this.allowReservedIpAddresses = config != null && config.isAllowReservedIpAddresses();
     }
 
     /**
@@ -292,5 +307,157 @@ public class DomainNameUtils {
      */
     public static boolean isValidEmailAddress(String email) {
         return EMAIL_PATTERN.matcher(email).matches();
+    }
+
+    // -----------------------------------------------------------------------
+    // IP address helpers
+    // -----------------------------------------------------------------------
+
+    /**
+     * Checks if the given value is an IP address (IPv4 or IPv6).
+     * <p>
+     * Uses BouncyCastle {@link IPAddress#isValid(String)} for consistent, pure-parser validation
+     * with no DNS resolution side-effects.
+     *
+     * @param value the value to check
+     * @return true if the value is a valid IPv4 or IPv6 address, false otherwise
+     */
+    public static boolean isIpAddress(String value) {
+        if (StringUtils.isEmpty(value)) return false;
+        return IPAddress.isValid(value);
+    }
+
+    /**
+     * Validates the given value as either a domain name or an IP address.
+     * <p>
+     * If the value is a valid IP address (per {@link #isIpAddress(String)}), it is checked against
+     * private and reserved ranges. Private IPv4 ranges (RFC 1918), reserved IPv4 ranges, loopback,
+     * link-local, and multicast addresses are rejected with {@link DcvError#IP_ADDRESS_RESERVED}.
+     * For IPv6, only Global Unicast addresses ({@code 2000::/3}) are permitted.
+     * <p>
+     * If the value does not look like an IP address, it is validated as a domain name via
+     * {@link #validateDomainName(String)}.
+     *
+     * @param value the domain name or IP address to validate
+     * @throws InputException if the value is empty, is a private/reserved IP address,
+     *                        or is not a valid domain name
+     */
+    public void validateDomainOrIpAddress(String value) throws InputException {
+        if (StringUtils.isEmpty(value)) {
+            throw new InputException(DcvError.DOMAIN_REQUIRED);
+        }
+        if (isIpAddress(value)) {
+            if (isPrivateOrReservedIpAddress(value)) {
+                throw new InputException(DcvError.IP_ADDRESS_RESERVED);
+            }
+            return;
+        }
+        validateDomainName(value);
+    }
+
+    /**
+     * Returns true if the IP address is in a private or reserved range.
+     * <p>
+     * For IPv4: rejects RFC 1918 private ranges, loopback, link-local, multicast, and other
+     * IANA-reserved blocks (mirroring {@code ValidationUtils.isPrivateIpv4} and
+     * {@code ValidationUtils.isReservedIpv4}).
+     * <p>
+     * For IPv6: rejects all addresses outside the Global Unicast range ({@code 2000::/3}).
+     * <p>
+     * If {@code allowReservedIpAddresses} is {@code true}, this method always returns {@code false}
+     * and logs a warning instead of rejecting the address.
+     *
+     * @param ip a value already confirmed to be a valid IP address via {@link #isIpAddress(String)}
+     * @return true if the address is private or reserved and the check is enforced, false otherwise
+     */
+    private boolean isPrivateOrReservedIpAddress(String ip) {
+        boolean reserved = IPAddress.isValidIPv4(ip) ? isPrivateOrReservedIpv4(ip) : !isPublicIPv6(ip);
+        if (reserved && allowReservedIpAddresses) {
+            log.warn("event_id={} ip_address={} message=\"Reserved IP check bypassed - ensure this is running in a test environment only\"",
+                    LogEvents.RESERVED_IP_CHECK_BYPASSED, ip);
+            return false;
+        }
+        return reserved;
+    }
+
+    /**
+     * All IPv4 ranges that are private, reserved, or otherwise not permitted for DCV.
+     * Initialised once as a static constant.
+     * <p>
+     * Covers:
+     * <ul>
+     *   <li>RFC 1918 private ranges: 10/8, 172.16/12, 192.168/16</li>
+     *   <li>Loopback: 127/8 (RFC 5735)</li>
+     *   <li>Multicast: 224/4 (RFC 1112)</li>
+     *   <li>"This" network: 0/8 (RFC 1700)</li>
+     *   <li>Shared address space: 100.64/10 (RFC 6598)</li>
+     *   <li>Link-local: 169.254/16 (RFC 3927)</li>
+     *   <li>IETF protocol assignments: 192.0.0/24 (RFC 5736)</li>
+     *   <li>TEST-NET-1/2/3: 192.0.2/24, 198.51.100/24, 203.0.113/24 (RFC 5737)</li>
+     *   <li>6to4 relay anycast: 192.88.99/24 (RFC 3068)</li>
+     *   <li>Benchmarking: 198.18/15 (RFC 2544)</li>
+     *   <li>Reserved: 240/4 – 255.255.255.255 (RFC 6890)</li>
+     * </ul>
+     */
+    private static final Map<Long, Long> RESTRICTED_IPV4_RANGES = Map.ofEntries(
+            Map.entry(ipToLong("10.0.0.0"),      ipToLong("10.255.255.255")),   // RFC 1918
+            Map.entry(ipToLong("172.16.0.0"),    ipToLong("172.31.255.255")),   // RFC 1918
+            Map.entry(ipToLong("192.168.0.0"),   ipToLong("192.168.255.255")),  // RFC 1918
+            Map.entry(ipToLong("127.0.0.0"),     ipToLong("127.255.255.255")),  // loopback RFC 5735
+            Map.entry(ipToLong("224.0.0.0"),     ipToLong("239.255.255.255")),  // multicast RFC 1112
+            Map.entry(ipToLong("0.0.0.0"),       ipToLong("0.255.255.255")),    // RFC 1700
+            Map.entry(ipToLong("100.64.0.0"),    ipToLong("100.127.255.255")),  // RFC 6598
+            Map.entry(ipToLong("169.254.0.0"),   ipToLong("169.254.255.255")),  // RFC 3927 link-local
+            Map.entry(ipToLong("192.0.0.0"),     ipToLong("192.0.0.255")),      // RFC 5736
+            Map.entry(ipToLong("192.0.2.0"),     ipToLong("192.0.2.255")),      // RFC 5737
+            Map.entry(ipToLong("192.88.99.0"),   ipToLong("192.88.99.255")),    // RFC 3068
+            Map.entry(ipToLong("198.18.0.0"),    ipToLong("198.19.255.255")),   // RFC 2544
+            Map.entry(ipToLong("198.51.100.0"),  ipToLong("198.51.100.255")),   // RFC 5737
+            Map.entry(ipToLong("203.0.113.0"),   ipToLong("203.0.113.255")),    // RFC 5737
+            Map.entry(ipToLong("240.0.0.0"),     ipToLong("255.255.255.255"))   // RFC 6890
+    );
+
+    /**
+     * Returns true if the IPv4 address is in a private or reserved range.
+     * Covers RFC 1918 private ranges, loopback (127.x), link-local (169.254.x),
+     * multicast (224-239.x), and additional IANA-reserved blocks.
+     */
+    private static boolean isPrivateOrReservedIpv4(String ip) {
+        long addr = ipToLong(ip);
+        for (Map.Entry<Long, Long> entry : RESTRICTED_IPV4_RANGES.entrySet()) {
+            if (isIpInRange(addr, entry.getKey(), entry.getValue())) return true;
+        }
+        return false;
+    }
+
+    /**
+     * Returns true if the IPv6 address is publicly routable (Global Unicast, {@code 2000::/3}).
+     * Only the Global Unicast range is considered a valid public address for DCV purposes.
+     * All other ranges (loopback ::1, link-local fe80::/10, ULA fc00::/7, etc.) are rejected.
+     */
+    private static boolean isPublicIPv6(String ip) {
+        try {
+            InetAddress addr = InetAddress.getByName(ip);
+            // 2000::/3 — first 3 bits must be 001 (first byte & 0xE0 == 0x20)
+            byte[] bytes = addr.getAddress();
+            if (bytes.length != 16) return false; // not IPv6
+            return (bytes[0] & 0xE0) == 0x20;
+        } catch (UnknownHostException e) {
+            return false;
+        }
+    }
+
+    /** Converts a dotted-decimal IPv4 string to a long value for range comparisons. */
+    private static long ipToLong(String ip) {
+        String[] parts = ip.split("\\.");
+        return (Long.parseLong(parts[0]) << 24) +
+               (Long.parseLong(parts[1]) << 16) +
+               (Long.parseLong(parts[2]) << 8) +
+                Long.parseLong(parts[3]);
+    }
+
+    /** Returns true if {@code address} falls within [{@code begin}, {@code end}] inclusive. */
+    private static boolean isIpInRange(long address, long begin, long end) {
+        return address >= begin && address <= end;
     }
 }

--- a/library/src/test/java/com/digicert/validation/methods/file/FileValidatorTest.java
+++ b/library/src/test/java/com/digicert/validation/methods/file/FileValidatorTest.java
@@ -52,6 +52,60 @@ class FileValidatorTest {
     }
 
     @Test
+    void testVerifyFileValidationRequest_ipv4_withBR_3_2_2_5_1_shouldSucceed() {
+        // Arrange
+        FileValidationRequest request = FileValidationRequest.builder()
+                .domain("1.2.3.4")
+                .randomValue(defaultRandomValue)
+                .challengeType(ChallengeType.RANDOM_VALUE)
+                .validationState(new ValidationState("1.2.3.4", Instant.now(), DcvMethod.BR_3_2_2_5_1))
+                .build();
+        // Act & Assert
+        assertDoesNotThrow(() -> fileValidator.verifyFileValidationRequest(request));
+    }
+
+    @Test
+    void testVerifyFileValidationRequest_ipv6_withBR_3_2_2_5_1_shouldSucceed() {
+        // Arrange
+        FileValidationRequest request = FileValidationRequest.builder()
+                .domain("2001:db8::1")
+                .randomValue(defaultRandomValue)
+                .challengeType(ChallengeType.RANDOM_VALUE)
+                .validationState(new ValidationState("2001:db8::1", Instant.now(), DcvMethod.BR_3_2_2_5_1))
+                .build();
+        // Act & Assert
+        assertDoesNotThrow(() -> fileValidator.verifyFileValidationRequest(request));
+    }
+
+    @Test
+    void testVerifyFileValidationRequest_ipv4_withBR_3_2_2_4_18_shouldThrowInvalidDcvMethod() {
+        // Arrange — IP address subject but wrong DCV method (domain method)
+        FileValidationRequest request = FileValidationRequest.builder()
+                .domain("1.2.3.4")
+                .randomValue(defaultRandomValue)
+                .challengeType(ChallengeType.RANDOM_VALUE)
+                .validationState(new ValidationState("1.2.3.4", Instant.now(), DcvMethod.BR_3_2_2_4_18))
+                .build();
+        // Act & Assert
+        InputException exception = assertThrows(InputException.class, () -> fileValidator.verifyFileValidationRequest(request));
+        assertTrue(exception.getErrors().contains(DcvError.INVALID_DCV_METHOD));
+    }
+
+    @Test
+    void testVerifyFileValidationRequest_domain_withBR_3_2_2_5_1_shouldThrowInvalidDcvMethod() {
+        // Arrange — domain subject but wrong DCV method (IP method)
+        FileValidationRequest request = FileValidationRequest.builder()
+                .domain("example.com")
+                .randomValue(defaultRandomValue)
+                .challengeType(ChallengeType.RANDOM_VALUE)
+                .validationState(new ValidationState("example.com", Instant.now(), DcvMethod.BR_3_2_2_5_1))
+                .build();
+        // Act & Assert
+        InputException exception = assertThrows(InputException.class, () -> fileValidator.verifyFileValidationRequest(request));
+        assertTrue(exception.getErrors().contains(DcvError.INVALID_DCV_METHOD));
+    }
+
+    @Test
     void testVerifyFileValidationRequest_InvalidDomain() {
         // Arrange
         FileValidationRequest request = getRandomValueFileValidationRequest()
@@ -111,6 +165,42 @@ class FileValidatorTest {
         FilePreparationRequest filePreparationRequest = new FilePreparationRequest("example.com");
         FilePreparationResponse response = fileValidator.prepare(filePreparationRequest);
         assertEquals("example.com", response.getDomain());
+    }
+
+    @Test
+    void prepare_withIpv4Address_shouldUseBR_3_2_2_5_1Method() throws DcvException {
+        FilePreparationRequest request = new FilePreparationRequest("1.2.3.4");
+        FilePreparationResponse response = fileValidator.prepare(request);
+        assertEquals(DcvMethod.BR_3_2_2_5_1, response.getValidationState().dcvMethod());
+    }
+
+    @Test
+    void prepare_withIpv6Address_shouldUseBR_3_2_2_5_1Method() throws DcvException {
+        FilePreparationRequest request = new FilePreparationRequest("2001:db8::1");
+        FilePreparationResponse response = fileValidator.prepare(request);
+        assertEquals(DcvMethod.BR_3_2_2_5_1, response.getValidationState().dcvMethod());
+    }
+
+    @Test
+    void prepare_withDomainName_shouldUseBR_3_2_2_4_18Method() throws DcvException {
+        FilePreparationRequest request = new FilePreparationRequest("example.com");
+        FilePreparationResponse response = fileValidator.prepare(request);
+        assertEquals(DcvMethod.BR_3_2_2_4_18, response.getValidationState().dcvMethod());
+    }
+
+    @Test
+    void prepare_withPrivateIpv4_shouldThrowIpAddressReserved() {
+        FilePreparationRequest request = new FilePreparationRequest("192.168.1.1");
+        InputException exception = assertThrows(InputException.class, () -> fileValidator.prepare(request));
+        assertTrue(exception.getErrors().contains(DcvError.IP_ADDRESS_RESERVED));
+    }
+
+    @Test
+    void prepare_withPrivateIpv6_shouldThrowIpAddressReserved() {
+        // fe80::/10 is link-local — not a Global Unicast address
+        FilePreparationRequest request = new FilePreparationRequest("fe80::1");
+        InputException exception = assertThrows(InputException.class, () -> fileValidator.prepare(request));
+        assertTrue(exception.getErrors().contains(DcvError.IP_ADDRESS_RESERVED));
     }
 
     @Test

--- a/library/src/test/java/com/digicert/validation/methods/file/FileValidatorTest.java
+++ b/library/src/test/java/com/digicert/validation/methods/file/FileValidatorTest.java
@@ -66,12 +66,12 @@ class FileValidatorTest {
 
     @Test
     void testVerifyFileValidationRequest_ipv6_withBR_3_2_2_5_1_shouldSucceed() {
-        // Arrange
+        // Arrange — use a genuinely public IPv6 address (ARIN allocation); 2001:db8:: is documentation-only and is rejected
         FileValidationRequest request = FileValidationRequest.builder()
-                .domain("2001:db8::1")
+                .domain("2600::1")
                 .randomValue(defaultRandomValue)
                 .challengeType(ChallengeType.RANDOM_VALUE)
-                .validationState(new ValidationState("2001:db8::1", Instant.now(), DcvMethod.BR_3_2_2_5_1))
+                .validationState(new ValidationState("2600::1", Instant.now(), DcvMethod.BR_3_2_2_5_1))
                 .build();
         // Act & Assert
         assertDoesNotThrow(() -> fileValidator.verifyFileValidationRequest(request));
@@ -176,7 +176,8 @@ class FileValidatorTest {
 
     @Test
     void prepare_withIpv6Address_shouldUseBR_3_2_2_5_1Method() throws DcvException {
-        FilePreparationRequest request = new FilePreparationRequest("2001:db8::1");
+        // Use a genuinely public IPv6 address (ARIN allocation); 2001:db8:: is documentation-only and is rejected
+        FilePreparationRequest request = new FilePreparationRequest("2600::1");
         FilePreparationResponse response = fileValidator.prepare(request);
         assertEquals(DcvMethod.BR_3_2_2_5_1, response.getValidationState().dcvMethod());
     }
@@ -229,6 +230,36 @@ class FileValidatorTest {
     void fileValidationPreparationResponse_InvalidCustomFilename() {
         FilePreparationRequest filePreparationRequest = new FilePreparationRequest("example.com", "invalid*filename.txt", ChallengeType.RANDOM_VALUE);
         assertThrows(IllegalArgumentException.class, () -> fileValidator.prepare(filePreparationRequest));
+    }
+
+    @Test
+    void verifyFileValidationRequest_randomValueInFilename_shouldThrowChallengeValueInRequestNotAllowed() {
+        // The random value must not appear in the GET request URL (BR requirement).
+        // Embedding it in the filename would expose it on the wire pre-fetch.
+        FileValidationRequest request = FileValidationRequest.builder()
+                .domain("example.com")
+                .randomValue(defaultRandomValue)
+                .filename(defaultRandomValue + ".txt")   // random value embedded in filename
+                .challengeType(ChallengeType.RANDOM_VALUE)
+                .validationState(new ValidationState("example.com", Instant.now(), DcvMethod.BR_3_2_2_4_18))
+                .build();
+        InputException exception = assertThrows(InputException.class,
+                () -> fileValidator.verifyFileValidationRequest(request));
+        assertTrue(exception.getErrors().contains(DcvError.CHALLENGE_VALUE_IN_REQUEST_NOT_ALLOWED));
+    }
+
+    @Test
+    void verifyFileValidationRequest_invalidFilenameFormat_shouldThrowIllegalArgumentException() {
+        // Filename validation must also run in the validate path, not only in prepare.
+        FileValidationRequest request = FileValidationRequest.builder()
+                .domain("example.com")
+                .randomValue(defaultRandomValue)
+                .filename("invalid*filename.txt")   // '*' is not an allowed filename character
+                .challengeType(ChallengeType.RANDOM_VALUE)
+                .validationState(new ValidationState("example.com", Instant.now(), DcvMethod.BR_3_2_2_4_18))
+                .build();
+        assertThrows(IllegalArgumentException.class,
+                () -> fileValidator.verifyFileValidationRequest(request));
     }
 
     @Test

--- a/library/src/test/java/com/digicert/validation/methods/file/validate/FileValidationHandlerTest.java
+++ b/library/src/test/java/com/digicert/validation/methods/file/validate/FileValidationHandlerTest.java
@@ -399,6 +399,50 @@ class FileValidationHandlerTest {
                 .build();
     }
 
+    @Test
+    void testValidate_randomValueInFilename_shouldFail_withChallengeValueInRequestNotAllowed() {
+        // Final-gate check: if the located random value is embedded in the caller-supplied
+        // filename, it was already present in the GET request URL and must be rejected.
+        String randomValue = "randomValue";
+        FileValidationRequest request = getRandomValueFileValidationRequestBuilder()
+                .filename(randomValue + ".txt")   // secret embedded in filename
+                .build();
+        MpicFileDetails mpicFileDetails = getMpicFileDetails(true, null, 200, randomValue);
+        when(mpicFileService.getMpicFileDetails(anyList(), eq(randomValue))).thenReturn(mpicFileDetails);
+        ChallengeValidationResponse challengeValidationResponse =
+                new ChallengeValidationResponse(Optional.of(randomValue), null);
+        when(randomValueValidator.validate(anyString(), anyString())).thenReturn(challengeValidationResponse);
+
+        FileValidationResponse response = fileValidationHandler.validate(request);
+
+        assertFalse(response.isValid());
+        assertTrue(response.errors().contains(DcvError.CHALLENGE_VALUE_IN_REQUEST_NOT_ALLOWED));
+        assertNull(response.validRandomValue());
+    }
+
+    @Test
+    void testValidate_requestTokenInFilename_shouldFail_withChallengeValueInRequestNotAllowed() {
+        // Final-gate check for request tokens: the token value is only known post-fetch, so
+        // the pre-fetch guard in FileValidator cannot catch it. The handler's final gate must.
+        String tokenValue = "some-token-value";
+        FileValidationRequest request = getRequestTokenFileValidationRequestBuilder()
+                .filename(tokenValue + ".txt")   // token embedded in filename
+                .build();
+        PrimaryFileResponse primaryFileResponse = getPrimaryFileResponse(AgentStatus.FILE_SUCCESS);
+        when(mpicFileService.getPrimaryOnlyFileResponse(anyList())).thenReturn(primaryFileResponse);
+        ChallengeValidationResponse challengeValidationResponse =
+                new ChallengeValidationResponse(Optional.of(tokenValue), null);
+        when(requestTokenValidator.validate(any(), eq(tokenValue))).thenReturn(challengeValidationResponse);
+        when(mpicFileService.getMpicFileDetails(eq(primaryFileResponse.fileUrl()), eq(tokenValue)))
+                .thenReturn(getMpicFileDetails(true, null, 200, tokenValue));
+
+        FileValidationResponse response = fileValidationHandler.validate(request);
+
+        assertFalse(response.isValid());
+        assertTrue(response.errors().contains(DcvError.CHALLENGE_VALUE_IN_REQUEST_NOT_ALLOWED));
+        assertNull(response.validRequestToken());
+    }
+
 
     private FileValidationRequest.FileValidationRequestBuilder getRandomValueFileValidationRequestBuilder() {
         return FileValidationRequest.builder()

--- a/library/src/test/java/com/digicert/validation/methods/file/validate/FileValidationHandlerTest.java
+++ b/library/src/test/java/com/digicert/validation/methods/file/validate/FileValidationHandlerTest.java
@@ -109,6 +109,64 @@ class FileValidationHandlerTest {
     }
 
     @Test
+    void testGetFileUrls_ipv4_noHttps() {
+        // Arrange
+        DcvConfiguration dcvConfiguration = new DcvConfiguration.DcvConfigurationBuilder().fileValidationCheckHttps(false).build();
+        initializeMocks(dcvConfiguration);
+        FileValidationRequest request = getRandomValueFileValidationRequestBuilder()
+                .domain("1.2.3.4")
+                .build();
+        // Act
+        List<String> fileUrls = fileValidationHandler.getFileUrls(request);
+        // Assert
+        assertEquals(1, fileUrls.size());
+        assertEquals("http://1.2.3.4/.well-known/pki-validation/fileauth.txt", fileUrls.get(0));
+    }
+
+    @Test
+    void testGetFileUrls_ipv6_bracketWrapped() {
+        // Arrange
+        DcvConfiguration dcvConfiguration = new DcvConfiguration.DcvConfigurationBuilder().fileValidationCheckHttps(false).build();
+        initializeMocks(dcvConfiguration);
+        FileValidationRequest request = getRandomValueFileValidationRequestBuilder()
+                .domain("2001:db8::1")
+                .build();
+        // Act
+        List<String> fileUrls = fileValidationHandler.getFileUrls(request);
+        // Assert
+        assertEquals(1, fileUrls.size());
+        assertEquals("http://[2001:db8::1]/.well-known/pki-validation/fileauth.txt", fileUrls.get(0));
+    }
+
+    @Test
+    void testGetFileUrls_ipv6_fullAddress_bracketWrapped() {
+        // Arrange
+        DcvConfiguration dcvConfiguration = new DcvConfiguration.DcvConfigurationBuilder().fileValidationCheckHttps(false).build();
+        initializeMocks(dcvConfiguration);
+        FileValidationRequest request = getRandomValueFileValidationRequestBuilder()
+                .domain("2001:0db8:85a3:0000:0000:8a2e:0370:7334")
+                .build();
+        // Act
+        List<String> fileUrls = fileValidationHandler.getFileUrls(request);
+        // Assert
+        assertEquals(1, fileUrls.size());
+        assertEquals("http://[2001:0db8:85a3:0000:0000:8a2e:0370:7334]/.well-known/pki-validation/fileauth.txt", fileUrls.get(0));
+    }
+
+    @Test
+    void testGetFileUrls_domain_notBracketWrapped() {
+        // Arrange
+        DcvConfiguration dcvConfiguration = new DcvConfiguration.DcvConfigurationBuilder().fileValidationCheckHttps(false).build();
+        initializeMocks(dcvConfiguration);
+        // Act
+        List<String> fileUrls = fileValidationHandler.getFileUrls(getRandomValueFileValidationRequest());
+        // Assert
+        assertEquals(1, fileUrls.size());
+        assertEquals("http://example.com/.well-known/pki-validation/fileauth.txt", fileUrls.get(0));
+        assertFalse(fileUrls.get(0).contains("["));
+    }
+
+    @Test
     void testValidate_validResponse() {
         // Arrange
         when(mpicFileService.getMpicFileDetails(anyList(), eq("randomValue"))).thenReturn(getMpicFileDetails(true, null, 200, "randomValue"));

--- a/library/src/test/java/com/digicert/validation/utils/DomainNameUtilsTest.java
+++ b/library/src/test/java/com/digicert/validation/utils/DomainNameUtilsTest.java
@@ -353,4 +353,142 @@ class DomainNameUtilsTest {
             assertFalse(DomainNameUtils.isValidEmailAddress(email));
         }
     }
+
+    // -----------------------------------------------------------------------
+    // isIpAddress
+    // -----------------------------------------------------------------------
+
+    static Stream<Arguments> provideIsIpAddressTestData() {
+        return Stream.of(
+                // IPv4 — should be recognised as IP
+                Arguments.of("1.2.3.4",               true),
+                Arguments.of("192.168.1.1",            true),
+                Arguments.of("0.0.0.0",                true),
+                Arguments.of("255.255.255.255",        true),
+                // IPv6 — should be recognised as IP (contains ":")
+                Arguments.of("2001:db8::1",            true),
+                Arguments.of("2001:0db8:85a3:0000:0000:8a2e:0370:7334", true),
+                Arguments.of("::1",                    true),
+                Arguments.of("::ffff:1.2.3.4",         true),
+                // Domain names — should NOT be recognised as IP
+                Arguments.of("example.com",            false),
+                Arguments.of("sub.example.com",        false),
+                // Strings that have letters mixed with IPv4-like dots
+                Arguments.of("a12.0.0.1",              false),
+                // Out-of-range IPv4 — BouncyCastle rejects these as invalid
+                Arguments.of("256.0.0.1",              false),
+                // Empty / null
+                Arguments.of("",                       false),
+                Arguments.of(null,                     false),
+                // already-bracketed IPv6 — rejected by BouncyCastle IPAddress.isValid()
+                Arguments.of("[2001:db8::1]",          false),
+                // host:port format — rejected by BouncyCastle IPAddress.isValid()
+                Arguments.of("example.com:8080",       false)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideIsIpAddressTestData")
+    void isIpAddress(String value, boolean expected) {
+        assertEquals(expected, DomainNameUtils.isIpAddress(value));
+    }
+
+    // -----------------------------------------------------------------------
+    // validateDomainOrIpAddress — valid inputs (should not throw)
+    // -----------------------------------------------------------------------
+
+    static Stream<Arguments> provideValidateDomainOrIpAddress_valid() {
+        return Stream.of(
+                // Valid domain names
+                Arguments.of("example.com"),
+                Arguments.of("sub.example.com"),
+                // Valid public IPv4
+                Arguments.of("1.2.3.4"),
+                Arguments.of("203.0.114.42"),    // outside the RFC 5737 doc range
+                Arguments.of("8.8.8.8"),
+                // Valid public IPv6 (Global Unicast 2000::/3)
+                Arguments.of("2001:db8::1"),
+                Arguments.of("2001:0db8:85a3:0000:0000:8a2e:0370:7334"),
+                Arguments.of("2600::1")
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideValidateDomainOrIpAddress_valid")
+    void validateDomainOrIpAddress_valid(String value) {
+        assertDoesNotThrow(() -> domainNameUtils.validateDomainOrIpAddress(value));
+    }
+
+    // -----------------------------------------------------------------------
+    // validateDomainOrIpAddress — invalid inputs (should throw)
+    // -----------------------------------------------------------------------
+
+    static Stream<Arguments> provideValidateDomainOrIpAddress_invalid() {
+        return Stream.of(
+                // Missing input
+                Arguments.of(null,              DcvError.DOMAIN_REQUIRED),
+                Arguments.of("",               DcvError.DOMAIN_REQUIRED),
+                // Invalid IPv4 (out of range) — IPAddress.isValid() returns false, falls through to domain validation
+                Arguments.of("256.0.0.1",      DcvError.DOMAIN_INVALID_INCORRECT_NAME_PATTERN),
+                // Invalid IPv6 — falls through to domain validation
+                Arguments.of("2001::85a3::7334", DcvError.DOMAIN_INVALID_INCORRECT_NAME_PATTERN),
+                // Invalid domain
+                Arguments.of("example.invalid", DcvError.DOMAIN_INVALID_NOT_UNDER_PUBLIC_SUFFIX),
+                // Private IPv4 — RFC 1918
+                Arguments.of("10.0.0.1",        DcvError.IP_ADDRESS_RESERVED),
+                Arguments.of("172.16.0.1",      DcvError.IP_ADDRESS_RESERVED),
+                Arguments.of("192.168.1.1",     DcvError.IP_ADDRESS_RESERVED),
+                // Loopback
+                Arguments.of("127.0.0.1",       DcvError.IP_ADDRESS_RESERVED),
+                // Link-local
+                Arguments.of("169.254.1.1",     DcvError.IP_ADDRESS_RESERVED),
+                // Multicast
+                Arguments.of("224.0.0.1",       DcvError.IP_ADDRESS_RESERVED),
+                // Reserved
+                Arguments.of("198.51.100.1",    DcvError.IP_ADDRESS_RESERVED),
+                Arguments.of("203.0.113.1",     DcvError.IP_ADDRESS_RESERVED),
+                // IPv6 loopback
+                Arguments.of("::1",             DcvError.IP_ADDRESS_RESERVED),
+                // IPv6 link-local
+                Arguments.of("fe80::1",         DcvError.IP_ADDRESS_RESERVED),
+                // IPv6 ULA (fc00::/7)
+                Arguments.of("fc00::1",         DcvError.IP_ADDRESS_RESERVED)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideValidateDomainOrIpAddress_invalid")
+    void validateDomainOrIpAddress_invalid(String value, DcvError expectedError) {
+        InputException exception = assertThrows(InputException.class,
+                () -> domainNameUtils.validateDomainOrIpAddress(value));
+        assertTrue(exception.getErrors().contains(expectedError),
+                "expected error: " + expectedError + ", got: " + exception.getErrors());
+    }
+
+    // -----------------------------------------------------------------------
+    // validateDomainOrIpAddress — allowReservedIpAddresses bypass (test-only)
+    // -----------------------------------------------------------------------
+
+    static Stream<Arguments> provideReservedIpAddresses() {
+        return Stream.of(
+                Arguments.of("10.0.0.1"),
+                Arguments.of("172.16.0.1"),
+                Arguments.of("192.168.1.1"),
+                Arguments.of("127.0.0.1"),
+                Arguments.of("169.254.1.1"),
+                Arguments.of("224.0.0.1"),
+                Arguments.of("::1"),
+                Arguments.of("fe80::1")
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideReservedIpAddresses")
+    void validateDomainOrIpAddress_allowReservedIpAddresses_bypassesReservedCheck(String reservedIp) {
+        DcvConfiguration config = new DcvConfiguration.DcvConfigurationBuilder()
+                .allowReservedIpAddresses(true)
+                .build();
+        DomainNameUtils utils = new DomainNameUtils(new DcvContext(config));
+        assertDoesNotThrow(() -> utils.validateDomainOrIpAddress(reservedIp));
+    }
 }

--- a/library/src/test/java/com/digicert/validation/utils/DomainNameUtilsTest.java
+++ b/library/src/test/java/com/digicert/validation/utils/DomainNameUtilsTest.java
@@ -409,10 +409,10 @@ class DomainNameUtilsTest {
                 Arguments.of("1.2.3.4"),
                 Arguments.of("203.0.114.42"),    // outside the RFC 5737 doc range
                 Arguments.of("8.8.8.8"),
-                // Valid public IPv6 (Global Unicast 2000::/3)
-                Arguments.of("2001:db8::1"),
-                Arguments.of("2001:0db8:85a3:0000:0000:8a2e:0370:7334"),
-                Arguments.of("2600::1")
+                // Valid public IPv6 (Global Unicast 2000::/3, outside IANA special-purpose sub-ranges)
+                Arguments.of("2600::1"),          // ARIN allocation — genuinely public
+                Arguments.of("2607:f8b0::1"),     // Google — genuinely public
+                Arguments.of("2400::1")           // APNIC allocation — genuinely public
         );
     }
 
@@ -455,7 +455,15 @@ class DomainNameUtilsTest {
                 // IPv6 link-local
                 Arguments.of("fe80::1",         DcvError.IP_ADDRESS_RESERVED),
                 // IPv6 ULA (fc00::/7)
-                Arguments.of("fc00::1",         DcvError.IP_ADDRESS_RESERVED)
+                Arguments.of("fc00::1",         DcvError.IP_ADDRESS_RESERVED),
+                // IPv6 documentation prefix 2001:db8::/32 (RFC 3849) — must be rejected like IPv4 TEST-NET
+                Arguments.of("2001:db8::1",              DcvError.IP_ADDRESS_RESERVED),
+                Arguments.of("2001:0db8:85a3:0000:0000:8a2e:0370:7334", DcvError.IP_ADDRESS_RESERVED),
+                // IPv6 IETF Protocol Assignments 2001::/23 — Teredo, benchmarking, ORCHID
+                Arguments.of("2001::1",          DcvError.IP_ADDRESS_RESERVED),  // Teredo 2001::/32
+                Arguments.of("2001:2::1",        DcvError.IP_ADDRESS_RESERVED),  // benchmarking 2001:2::/48
+                Arguments.of("2001:10::1",       DcvError.IP_ADDRESS_RESERVED),  // ORCHID 2001:10::/28
+                Arguments.of("2001:20::1",       DcvError.IP_ADDRESS_RESERVED)   // ORCHID v2 2001:20::/28
         );
     }
 

--- a/library/src/test/java/com/digicert/validation/utils/DomainNameUtilsTest.java
+++ b/library/src/test/java/com/digicert/validation/utils/DomainNameUtilsTest.java
@@ -221,6 +221,7 @@ class DomainNameUtilsTest {
     void getBaseDomainWithPslOverrides(String domain, String expectedBaseDomain) throws InputException {
         DcvContext dcvContext = mock(DcvContext.class);
         doReturn(supplierWithOverrides).when(dcvContext).get(PslOverrideSupplier.class);
+        doReturn(new DcvConfiguration.DcvConfigurationBuilder().build()).when(dcvContext).getDcvConfiguration();
         DomainNameUtils overriddenUtils = new DomainNameUtils(dcvContext);
         assertEquals(expectedBaseDomain, overriddenUtils.getBaseDomain(domain));
     }
@@ -247,6 +248,7 @@ class DomainNameUtilsTest {
     void getBaseDomainWithPslOverrides_invalid(String domain) {
         DcvContext dcvContext = mock(DcvContext.class);
         doReturn(supplierWithOverrides).when(dcvContext).get(PslOverrideSupplier.class);
+        doReturn(new DcvConfiguration.DcvConfigurationBuilder().build()).when(dcvContext).getDcvConfiguration();
         DomainNameUtils overriddenUtils = new DomainNameUtils(dcvContext);
         assertThrows(InputException.class, () -> overriddenUtils.getBaseDomain(domain));
     }
@@ -277,6 +279,7 @@ class DomainNameUtilsTest {
     void getBaseDomain_invalid(String domain) {
         DcvContext dcvContext = mock(DcvContext.class);
         doReturn(supplierWithOverrides).when(dcvContext).get(PslOverrideSupplier.class);
+        doReturn(new DcvConfiguration.DcvConfigurationBuilder().build()).when(dcvContext).getDcvConfiguration();
         DomainNameUtils overriddenUtils = new DomainNameUtils(dcvContext);
         InputException inputException = assertThrows(InputException.class, () -> overriddenUtils.getBaseDomain(domain));
         assertTrue(inputException.getErrors().contains(DcvError.DOMAIN_INVALID_INCORRECT_NAME_PATTERN));


### PR DESCRIPTION
## Summary
Adds IP address support to the DCV library's file validation method, implementing BR 3.2.2.5.1 (Agreed-Upon Change to Website — IP Address).
## Changes
### Library
- **`DcvMethod`** — Added `BR_3_2_2_5_1` enum value for IP address file DCV
- **`DcvError`** — Added `IP_ADDRESS_RESERVED` error for private/reserved IP rejection
- **`LogEvents`** — Added `RESERVED_IP_CHECK_BYPASSED` log event
- **`DcvConfiguration`** — Added `allowReservedIpAddresses` flag (default `false`) with builder method; intended for non-production test environments only
- **`DomainNameUtils`** — Added `isIpAddress()`, `validateDomainOrIpAddress()`, and reserved IP range checks covering RFC 1918, loopback, link-local, multicast, and all other IANA-reserved IPv4 blocks; IPv6 restricted to Global Unicast (`2000::/3`). All restricted ranges consolidated into a single static `RESTRICTED_IPV4_RANGES` map
- **`FileValidator`** — Routes IP address subjects to `BR_3_2_2_5_1` and domain subjects to `BR_3_2_2_4_18`; uses `validateDomainOrIpAddress()` in place of `validateDomainName()`
- **`FileValidationHandler`** — Added `formatHostForUrl()` to bracket-wrap IPv6 addresses in URLs per RFC 2732
- **`CustomDnsResolver`** — Short-circuits DNS lookup for IP address literals, delegating directly to the system resolver
### Tests
- **`FileValidatorTest`** — Unit tests for IP/domain method routing and reserved IP rejection
- **`FileValidationHandlerTest`** — Unit tests for IPv4, IPv6 (bracket-wrapped), and domain URL generation
- **`DomainNameUtilsTest`** — Parameterized tests for `isIpAddress()`, `validateDomainOrIpAddress()` valid/invalid inputs, and `allowReservedIpAddresses` bypass
- **`IpAddressFileMethodIT`** — Integration tests for happy-path IPv4 file validation (default filename, custom filename, null filename fallback)
- **`IpAddressFileRejectionIT`** — Parameterized integration tests verifying 9 reserved/private IP addresses are rejected when `allowReservedIpAddresses=false`
- **`AllowReservedIpDcvConfiguration`** — Test-only Spring config that enables `allowReservedIpAddresses=true` for local integration tests
## Notes
- `allowReservedIpAddresses` must **never** be set to `true` in production; it exists solely to allow integration tests to target local infrastructure (at `127.0.0.1`)